### PR TITLE
Move from manually set version to hatch-vcs; use github release tags …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "toolz-stubs"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Type stubs for toolz"
 readme = "README.md"
 authors = [
@@ -30,8 +30,11 @@ Repository = "https://github.com/mgrinshpon/toolz-stubs"
 Issues = "https://github.com/mgrinshpon/toolz-stubs/issues"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/toolz-stubs"]

--- a/uv.lock
+++ b/uv.lock
@@ -249,7 +249,6 @@ wheels = [
 
 [[package]]
 name = "toolz-stubs"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "toolz" },


### PR DESCRIPTION
…as the single source of truth for version numbers