### PR TITLE
#19 change juxt to be a closure rather than a class to enable explicit tuple return typing

### DIFF
--- a/src/toolz-stubs/functoolz.pyi
+++ b/src/toolz-stubs/functoolz.pyi
@@ -515,7 +515,58 @@ def complement[**P](func: typing.Callable[P, bool]) -> typing.Callable[P, bool]:
     """
     ...
 
-class juxt[**P, T]:
+@typing.overload
+def juxt() -> typing.Callable[..., tuple[()]]: ...
+@typing.overload
+def juxt[**P, T0](
+    fn_0: typing.Callable[P, T0],
+) -> typing.Callable[P, tuple[T0]]: ...
+@typing.overload
+def juxt[**P, T0, T1](
+    fn_0: typing.Callable[P, T0],
+    fn_1: typing.Callable[P, T1],
+) -> typing.Callable[P, tuple[T0, T1]]: ...
+@typing.overload
+def juxt[**P, T0, T1, T2](
+    fn_0: typing.Callable[P, T0],
+    fn_1: typing.Callable[P, T1],
+    fn_2: typing.Callable[P, T2],
+) -> typing.Callable[P, tuple[T0, T1, T2]]: ...
+@typing.overload
+def juxt[**P, T0, T1, T2, T3](
+    fn_0: typing.Callable[P, T0],
+    fn_1: typing.Callable[P, T1],
+    fn_2: typing.Callable[P, T2],
+    fn_3: typing.Callable[P, T3],
+) -> typing.Callable[P, tuple[T0, T1, T2, T3]]: ...
+@typing.overload
+def juxt[**P, T0, T1, T2, T3, T4](
+    fn_0: typing.Callable[P, T0],
+    fn_1: typing.Callable[P, T1],
+    fn_2: typing.Callable[P, T2],
+    fn_3: typing.Callable[P, T3],
+    fn_4: typing.Callable[P, T4],
+) -> typing.Callable[P, tuple[T0, T1, T2, T3, T4]]: ...
+@typing.overload
+def juxt[**P, T0, T1, T2, T3, T4, T5](
+    fn_0: typing.Callable[P, T0],
+    fn_1: typing.Callable[P, T1],
+    fn_2: typing.Callable[P, T2],
+    fn_3: typing.Callable[P, T3],
+    fn_4: typing.Callable[P, T4],
+    fn_5: typing.Callable[P, T5],
+) -> typing.Callable[P, tuple[T0, T1, T2, T3, T4, T5]]: ...
+@typing.overload
+def juxt[**P, T](
+    funcs: collections.abc.Iterable[typing.Callable[P, T]],
+) -> typing.Callable[P, tuple[T, ...]]: ...
+@typing.overload
+def juxt[**P, T](
+    *funcs: typing.Callable[P, T],
+) -> typing.Callable[P, tuple[T, ...]]: ...
+def juxt[**P, T](
+    *funcs: typing.Callable[P, T] | collections.abc.Iterable[typing.Callable[P, T]],
+) -> typing.Callable[P, tuple[T, ...]]:
     """Creates a function that calls several functions with the same arguments
 
     Takes several functions and returns a function that applies its arguments
@@ -531,12 +582,7 @@ class juxt[**P, T]:
     >>> juxt([inc, double])(10)
     (11, 20)
     """
-
-    def __init__(self, *funcs: typing.Callable[P, T]) -> None: ...
-    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> tuple[T, ...]: ...
-    @typing.override
-    def __getstate__(self) -> tuple[typing.Callable[P, T], ...]: ...
-    def __setstate__(self, state: tuple[typing.Callable[P, T], ...]) -> None: ...
+    ...
 
 def do[T](func: typing.Callable[[T], typing.Any], x: T) -> T:
     """Runs ``func`` on ``x``, returns ``x``

--- a/tests/test_functoolz.py
+++ b/tests/test_functoolz.py
@@ -25,10 +25,75 @@ def test_compose():
     _ = assert_type(composed("  hello  "), str)
 
 
-# TODO: curry typing needs improvement - add(5) returns int | curry[int]
-# which makes add_five(3) error because int isn't callable
-# @toolz.curry
-# def add(x: int, y: int) -> int:
-#     return x + y
-# add_five = add(5)
-# result3 = add_five(3)
+class TestJuxt:
+    """Tests for juxt function."""
+
+    def test_basic(self) -> None:
+        """juxt should apply multiple functions and return a tuple."""
+
+        def inc(x: int) -> int:
+            return x + 1
+
+        def double(x: int) -> int:
+            return x * 2
+
+        j = toolz.juxt(inc, double)
+        result = j(10)
+
+        _ = assert_type(result, tuple[int, int])
+        assert result == (11, 20)
+
+    def test_single_function(self) -> None:
+        """juxt with single function should return single-element tuple."""
+
+        def inc(x: int) -> int:
+            return x + 1
+
+        j = toolz.juxt(inc)
+        result = j(10)
+
+        _ = assert_type(result, tuple[int])
+        assert result == (11,)
+
+    def test_heterogeneous(self) -> None:
+        """juxt should support functions with different return types."""
+
+        def to_str(x: int) -> str:
+            return str(x)
+
+        def to_float(x: int) -> float:
+            return float(x)
+
+        def identity(x: int) -> int:
+            return x
+
+        j = toolz.juxt(to_str, to_float, identity)
+        result = j(42)
+
+        _ = assert_type(result, tuple[str, float, int])
+        assert result == ("42", 42.0, 42)
+
+    def test_list_input(self) -> None:
+        """juxt should accept a list of functions (less precise typing)."""
+
+        def inc(x: int) -> int:
+            return x + 1
+
+        def double(x: int) -> int:
+            return x * 2
+
+        funcs = [inc, double]
+        j = toolz.juxt(funcs)
+        result = j(10)
+
+        # List input can't have precise tuple length at type-check time
+        _ = assert_type(result, tuple[int, ...])
+        assert result == (11, 20)
+
+    def test_empty(self) -> None:
+        """juxt with no functions should return empty tuple."""
+        j = toolz.juxt()
+        result = j(10)
+
+        _ = assert_type(result, tuple[()])
+        assert result == ()

--- a/tests/test_tlz_functoolz.py
+++ b/tests/test_tlz_functoolz.py
@@ -71,20 +71,78 @@ def test_complement() -> None:
     assert is_odd(4) is False
 
 
-def test_juxt() -> None:
-    """juxt should apply multiple functions and return a tuple."""
+class TestJuxt:
+    """Tests for juxt function."""
 
-    def inc(x: int) -> int:
-        return x + 1
+    def test_basic(self) -> None:
+        """juxt should apply multiple functions and return a tuple."""
 
-    def double(x: int) -> int:
-        return x * 2
+        def inc(x: int) -> int:
+            return x + 1
 
-    j = tlz.juxt(inc, double)
-    result = j(10)
+        def double(x: int) -> int:
+            return x * 2
 
-    _ = assert_type(result, tuple[int, ...])
-    assert result == (11, 20)
+        j = tlz.juxt(inc, double)
+        result = j(10)
+
+        _ = assert_type(result, tuple[int, int])
+        assert result == (11, 20)
+
+    def test_single_function(self) -> None:
+        """juxt with single function should return single-element tuple."""
+
+        def inc(x: int) -> int:
+            return x + 1
+
+        j = tlz.juxt(inc)
+        result = j(10)
+
+        _ = assert_type(result, tuple[int])
+        assert result == (11,)
+
+    def test_heterogeneous(self) -> None:
+        """juxt should support functions with different return types."""
+
+        def to_str(x: int) -> str:
+            return str(x)
+
+        def to_float(x: int) -> float:
+            return float(x)
+
+        def identity(x: int) -> int:
+            return x
+
+        j = tlz.juxt(to_str, to_float, identity)
+        result = j(42)
+
+        _ = assert_type(result, tuple[str, float, int])
+        assert result == ("42", 42.0, 42)
+
+    def test_list_input(self) -> None:
+        """juxt should accept a list of functions (less precise typing)."""
+
+        def inc(x: int) -> int:
+            return x + 1
+
+        def double(x: int) -> int:
+            return x * 2
+
+        funcs = [inc, double]
+        j = tlz.juxt(funcs)
+        result = j(10)
+
+        # List input can't have precise tuple length at type-check time
+        _ = assert_type(result, tuple[int, ...])
+        assert result == (11, 20)
+
+    def test_empty(self) -> None:
+        """juxt with no functions should return empty tuple."""
+        j = tlz.juxt()
+        result = j(10)
+
+        _ = assert_type(result, tuple[()])
+        assert result == ()
 
 
 def test_do() -> None:


### PR DESCRIPTION
* Change `juxt` type sig
* Add tests to prove it works in both toolz and tlz

Closes #19 