### PR TITLE
Fix unique() to accept Iterable instead of Sequence (#43)

### DIFF
--- a/src/toolz-stubs/itertoolz.pyi
+++ b/src/toolz-stubs/itertoolz.pyi
@@ -175,7 +175,7 @@ def interleave[T](
     ...
 
 def unique[T](
-    seq: collections.abc.Sequence[T],
+    seq: collections.abc.Iterable[T],
     key: typing.Callable[[T], typing.Any] | None = None,
 ) -> collections.abc.Iterator[T]:
     """Return only unique elements of a sequence

--- a/tests/test_tlz_itertoolz.py
+++ b/tests/test_tlz_itertoolz.py
@@ -122,14 +122,21 @@ def test_frequencies() -> None:
     assert freqs["bird"] == 1
 
 
-def test_unique() -> None:
-    """unique should return distinct elements in order."""
-    nums = [1, 2, 1, 3, 2, 4, 1]
+class TestUnique:
+    def test_unique(self) -> None:
+        """unique should return distinct elements in order."""
+        nums = [1, 2, 1, 3, 2, 4, 1]
 
-    result = list(tlz.unique(nums))
+        result = list(tlz.unique(nums))
 
-    _ = assert_type(result, list[int])
-    assert result == [1, 2, 3, 4]
+        _ = assert_type(result, list[int])
+        assert result == [1, 2, 3, 4]
+
+    def test_unique_iterable(self):
+        iterable = iter(tlz.concatv(range(5), range(5)))
+        result = tlz.unique(iterable)
+        _ = assert_type(result, collections.abc.Iterator[int])
+        assert list(result) == list(range(5))
 
 
 def test_concat() -> None:


### PR DESCRIPTION
The unique() function in toolz operates on any iterable, not just sequences. Broadening the type from Sequence to Iterable matches the actual runtime behavior and allows callers to pass generators, iterators, and other non-sequence iterables without type errors.