### PR TITLE
Replace deprecated typing.Callable with collections.abc.Callable

### DIFF
--- a/src/toolz-stubs/curried/__init__.pyi
+++ b/src/toolz-stubs/curried/__init__.pyi
@@ -144,33 +144,36 @@ __all__ = [
 # Curried accumulate with explicit overloads for type safety
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def accumulate[T]() -> typing.Callable[..., collections.abc.Iterator[T]]: ...
+def accumulate[T]() -> collections.abc.Callable[..., collections.abc.Iterator[T]]: ...
 
 # Stage 1: Just binop - returns callable waiting for seq (and optional initial)
 @typing.overload
 def accumulate[T](
-    binop: typing.Callable[[T, T], T], /
-) -> typing.Callable[..., collections.abc.Iterator[T]]: ...
+    binop: collections.abc.Callable[[T, T], T], /
+) -> collections.abc.Callable[..., collections.abc.Iterator[T]]: ...
 
 # Stage 2a: binop + seq (no initial) - executes immediately
 @typing.overload
 def accumulate[T](
-    binop: typing.Callable[[T, T], T], seq: collections.abc.Iterable[T], /
+    binop: collections.abc.Callable[[T, T], T], seq: collections.abc.Iterable[T], /
 ) -> collections.abc.Iterator[T]: ...
 
 # Stage 2b: binop + seq + initial - executes immediately
 @typing.overload
 def accumulate[T](
-    binop: typing.Callable[[T, T], T],
+    binop: collections.abc.Callable[[T, T], T],
     seq: collections.abc.Iterable[T],
     initial: T,
     /,
 ) -> collections.abc.Iterator[T]: ...
 def accumulate[T](
-    binop: typing.Callable[[T, T], T] = ...,
+    binop: collections.abc.Callable[[T, T], T] = ...,
     seq: collections.abc.Iterable[T] = ...,
     initial: T = ...,
-) -> collections.abc.Iterator[T] | typing.Callable[..., collections.abc.Iterator[T]]:
+) -> (
+    collections.abc.Iterator[T]
+    | collections.abc.Callable[..., collections.abc.Iterator[T]]
+):
     """Curried version of accumulate
 
     Repeatedly apply binary function to a sequence, accumulating results.
@@ -207,25 +210,27 @@ def accumulate[T](
     ...
 
 @typing.overload
-def assoc[K, V]() -> typing.Callable[
+def assoc[K, V]() -> collections.abc.Callable[
     ..., dict[K, V] | collections.abc.MutableMapping[K, V]
 ]: ...
 @typing.overload
 def assoc[K, V](
     d: collections.abc.Mapping[K, V], /
-) -> typing.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]: ...
+) -> collections.abc.Callable[
+    ..., dict[K, V] | collections.abc.MutableMapping[K, V]
+]: ...
 @typing.overload
 def assoc[K, V](
     d: collections.abc.Mapping[K, V], key: K, /
-) -> typing.Callable[[V], dict[K, V]]: ...
+) -> collections.abc.Callable[[V], dict[K, V]]: ...
 @typing.overload
 def assoc[K, V](
     d: collections.abc.Mapping[K, V],
     key: K,
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> typing.Callable[[V], collections.abc.MutableMapping[K, V]]: ...
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+) -> collections.abc.Callable[[V], collections.abc.MutableMapping[K, V]]: ...
 @typing.overload
 def assoc[K, V](
     d: collections.abc.Mapping[K, V], key: K, value: V, /
@@ -237,18 +242,18 @@ def assoc[K, V](
     value: V,
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def assoc[K, V](
     d: collections.abc.Mapping[K, V] = ...,
     key: K = ...,
     value: V = ...,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> (
     dict[K, V]
     | collections.abc.MutableMapping[K, V]
-    | typing.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]
+    | collections.abc.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]
 ):
     """Curried version of assoc
 
@@ -292,13 +297,15 @@ assoc_in = curry(_dicttoolz.assoc_in)
 # Curried cons with explicit overloads for type safety
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def cons[T]() -> typing.Callable[..., collections.abc.Iterator[T]]: ...
+def cons[T]() -> collections.abc.Callable[..., collections.abc.Iterator[T]]: ...
 
 # Stage 1: Just el - returns callable waiting for seq
 @typing.overload
 def cons[T](
     el: T, /
-) -> typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]: ...
+) -> collections.abc.Callable[
+    [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+]: ...
 
 # Stage 2: Full application - executes immediately
 @typing.overload
@@ -309,8 +316,10 @@ def cons[T](
     el: T = ..., seq: collections.abc.Iterable[T] = ...
 ) -> (
     collections.abc.Iterator[T]
-    | typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]
-    | typing.Callable[..., collections.abc.Iterator[T]]
+    | collections.abc.Callable[
+        [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+    ]
+    | collections.abc.Callable[..., collections.abc.Iterator[T]]
 ):
     """Curried version of cons
 
@@ -341,18 +350,20 @@ dissoc = curry(_dicttoolz.dissoc)
 # Curried do with explicit overloads for type safety
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def do[T]() -> typing.Callable[..., T]: ...
+def do[T]() -> collections.abc.Callable[..., T]: ...
 
 # Stage 1: Just func - returns callable waiting for x
 @typing.overload
-def do[T](func: typing.Callable[[T], typing.Any], /) -> typing.Callable[[T], T]: ...
+def do[T](
+    func: collections.abc.Callable[[T], typing.Any], /
+) -> collections.abc.Callable[[T], T]: ...
 
 # Stage 2: Full application - executes immediately
 @typing.overload
-def do[T](func: typing.Callable[[T], typing.Any], x: T, /) -> T: ...
+def do[T](func: collections.abc.Callable[[T], typing.Any], x: T, /) -> T: ...
 def do[T](
-    func: typing.Callable[[T], typing.Any] = ..., x: T = ...
-) -> T | typing.Callable[[T], T] | typing.Callable[..., T]:
+    func: collections.abc.Callable[[T], typing.Any] = ..., x: T = ...
+) -> T | collections.abc.Callable[[T], T] | collections.abc.Callable[..., T]:
     """Curried version of do
 
     Runs func on x, returns x.
@@ -385,11 +396,13 @@ def do[T](
     ...
 
 @typing.overload
-def drop[T]() -> typing.Callable[..., collections.abc.Iterator[T]]: ...
+def drop[T]() -> collections.abc.Callable[..., collections.abc.Iterator[T]]: ...
 @typing.overload
 def drop[T](
     n: int, /
-) -> typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]: ...
+) -> collections.abc.Callable[
+    [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+]: ...
 @typing.overload
 def drop[T](
     n: int, seq: collections.abc.Iterable[T], /
@@ -398,8 +411,10 @@ def drop[T](
     n: int = ..., seq: collections.abc.Iterable[T] = ...
 ) -> (
     collections.abc.Iterator[T]
-    | typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]
-    | typing.Callable[..., collections.abc.Iterator[T]]
+    | collections.abc.Callable[
+        [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+    ]
+    | collections.abc.Callable[..., collections.abc.Iterator[T]]
 ):
     """Curried version of drop
 
@@ -427,35 +442,35 @@ def drop[T](
     ...
 
 @typing.overload
-def excepts[T, **P]() -> typing.Callable[..., _excepts_class[T, P]]: ...
+def excepts[T, **P]() -> collections.abc.Callable[..., _excepts_class[T, P]]: ...
 @typing.overload
 def excepts[T, **P](
     exc: type[Exception] | tuple[type[Exception], ...], /
 ) -> (
-    typing.Callable[[typing.Callable[P, T]], _excepts_class[T, P]]
-    | typing.Callable[
-        [typing.Callable[P, T], typing.Callable[[Exception], T]],
+    collections.abc.Callable[[collections.abc.Callable[P, T]], _excepts_class[T, P]]
+    | collections.abc.Callable[
+        [collections.abc.Callable[P, T], collections.abc.Callable[[Exception], T]],
         _excepts_class[T, P],
     ]
 ): ...
 @typing.overload
 def excepts[T, **P](
     exc: type[Exception] | tuple[type[Exception], ...],
-    func: typing.Callable[P, T],
+    func: collections.abc.Callable[P, T],
     /,
 ) -> _excepts_class[T, P]: ...
 @typing.overload
 def excepts[T, **P](
     exc: type[Exception] | tuple[type[Exception], ...],
-    func: typing.Callable[P, T],
-    handler: typing.Callable[[Exception], T],
+    func: collections.abc.Callable[P, T],
+    handler: collections.abc.Callable[[Exception], T],
     /,
 ) -> _excepts_class[T, P]: ...
 def excepts[T, **P](
     exc: type[Exception] | tuple[type[Exception], ...] = ...,
-    func: typing.Callable[P, T] = ...,
-    handler: typing.Callable[[Exception], T] | None = ...,
-) -> _excepts_class[T, P] | typing.Callable[..., _excepts_class[T, P]]:
+    func: collections.abc.Callable[P, T] = ...,
+    handler: collections.abc.Callable[[Exception], T] | None = ...,
+) -> _excepts_class[T, P] | collections.abc.Callable[..., _excepts_class[T, P]]:
     """Curried version of excepts
 
     A wrapper around a function to catch exceptions and dispatch to a handler.
@@ -502,58 +517,69 @@ def excepts[T, **P](
     ...
 
 @typing.overload
-def filter[T]() -> typing.Callable[
-    ..., collections.abc.Iterator[T] | typing.Callable[..., collections.abc.Iterator[T]]
+def filter[T]() -> collections.abc.Callable[
+    ...,
+    collections.abc.Iterator[T]
+    | collections.abc.Callable[..., collections.abc.Iterator[T]],
 ]: ...
 @typing.overload
 def filter[T](
     function: None, /
-) -> typing.Callable[
+) -> collections.abc.Callable[
     [collections.abc.Iterable[T | None]], collections.abc.Iterator[T]
 ]: ...
 @typing.overload
 def filter[S, T](
-    function: typing.Callable[[S], typing.TypeGuard[T]], /
-) -> typing.Callable[[collections.abc.Iterable[S]], collections.abc.Iterator[T]]: ...
+    function: collections.abc.Callable[[S], typing.TypeGuard[T]], /
+) -> collections.abc.Callable[
+    [collections.abc.Iterable[S]], collections.abc.Iterator[T]
+]: ...
 @typing.overload
 def filter[S, T](
-    function: typing.Callable[[S], TypeIs[T]], /
-) -> typing.Callable[[collections.abc.Iterable[S]], collections.abc.Iterator[T]]: ...
+    function: collections.abc.Callable[[S], TypeIs[T]], /
+) -> collections.abc.Callable[
+    [collections.abc.Iterable[S]], collections.abc.Iterator[T]
+]: ...
 @typing.overload
 def filter[T](
-    function: typing.Callable[[T], typing.Any], /
-) -> typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]: ...
+    function: collections.abc.Callable[[T], typing.Any], /
+) -> collections.abc.Callable[
+    [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+]: ...
 @typing.overload
 def filter[T](
     function: None, iterable: collections.abc.Iterable[T | None], /
 ) -> collections.abc.Iterator[T]: ...
 @typing.overload
 def filter[S, T](
-    function: typing.Callable[[S], typing.TypeGuard[T]],
+    function: collections.abc.Callable[[S], typing.TypeGuard[T]],
     iterable: collections.abc.Iterable[S],
     /,
 ) -> collections.abc.Iterator[T]: ...
 @typing.overload
 def filter[S, T](
-    function: typing.Callable[[S], TypeIs[T]],
+    function: collections.abc.Callable[[S], TypeIs[T]],
     iterable: collections.abc.Iterable[S],
     /,
 ) -> collections.abc.Iterator[T]: ...
 @typing.overload
 def filter[T](
-    function: typing.Callable[[T], typing.Any],
+    function: collections.abc.Callable[[T], typing.Any],
     iterable: collections.abc.Iterable[T],
     /,
 ) -> collections.abc.Iterator[T]: ...
 def filter[T](
-    function: typing.Callable[[T], typing.Any] | None = ...,
+    function: collections.abc.Callable[[T], typing.Any] | None = ...,
     iterable: collections.abc.Iterable[T] = ...,
 ) -> (
     collections.abc.Iterator[T]
-    | typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]
-    | typing.Callable[
+    | collections.abc.Callable[
+        [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+    ]
+    | collections.abc.Callable[
         ...,
-        collections.abc.Iterator[T] | typing.Callable[..., collections.abc.Iterator[T]],
+        collections.abc.Iterator[T]
+        | collections.abc.Callable[..., collections.abc.Iterator[T]],
     ]
 ):
     """Curried version of builtin filter function
@@ -577,16 +603,16 @@ def filter[T](
     ...
 
 @typing.overload
-def get[T]() -> typing.Callable[..., T | tuple[T, ...]]: ...
+def get[T]() -> collections.abc.Callable[..., T | tuple[T, ...]]: ...
 @typing.overload
 def get[T](
     ind: collections.abc.Sequence[typing.Any], /
 ) -> (
-    typing.Callable[
+    collections.abc.Callable[
         [collections.abc.Sequence[T] | collections.abc.Mapping[typing.Any, T]],
         tuple[T, ...],
     ]
-    | typing.Callable[
+    | collections.abc.Callable[
         [collections.abc.Sequence[T] | collections.abc.Mapping[typing.Any, T], T],
         tuple[T, ...],
     ]
@@ -595,10 +621,10 @@ def get[T](
 def get[T](
     ind: typing.Any, /
 ) -> (
-    typing.Callable[
+    collections.abc.Callable[
         [collections.abc.Sequence[T] | collections.abc.Mapping[typing.Any, T]], T
     ]
-    | typing.Callable[
+    | collections.abc.Callable[
         [collections.abc.Sequence[T] | collections.abc.Mapping[typing.Any, T], T], T
     ]
 ): ...
@@ -632,7 +658,7 @@ def get[T](
     ind: typing.Any | collections.abc.Sequence[typing.Any] = ...,
     seq: collections.abc.Sequence[T] | collections.abc.Mapping[typing.Any, T] = ...,
     default: T = ...,
-) -> T | tuple[T, ...] | typing.Callable[..., T | tuple[T, ...]]:
+) -> T | tuple[T, ...] | collections.abc.Callable[..., T | tuple[T, ...]]:
     """Curried version of get
 
     Get element(s) from a sequence or dict.
@@ -670,30 +696,32 @@ def get[T](
 get_in = curry(_dicttoolz.get_in)
 
 @typing.overload
-def groupby[KT, T]() -> typing.Callable[..., dict[KT, list[T]]]: ...
+def groupby[KT, T]() -> collections.abc.Callable[..., dict[KT, list[T]]]: ...
 @typing.overload
 def groupby[KT, T](
-    key: typing.Callable[[T], KT], /
-) -> typing.Callable[[collections.abc.Iterable[T]], dict[KT, list[T]]]: ...
+    key: collections.abc.Callable[[T], KT], /
+) -> collections.abc.Callable[[collections.abc.Iterable[T]], dict[KT, list[T]]]: ...
 @typing.overload
 def groupby[T](
     key: typing.Any, /
-) -> typing.Callable[[collections.abc.Iterable[T]], dict[typing.Any, list[T]]]: ...
+) -> collections.abc.Callable[
+    [collections.abc.Iterable[T]], dict[typing.Any, list[T]]
+]: ...
 @typing.overload
 def groupby[KT, T](
-    key: typing.Callable[[T], KT], seq: collections.abc.Iterable[T], /
+    key: collections.abc.Callable[[T], KT], seq: collections.abc.Iterable[T], /
 ) -> dict[KT, list[T]]: ...
 @typing.overload
 def groupby[T](
     key: typing.Any, seq: collections.abc.Iterable[T], /
 ) -> dict[typing.Any, list[T]]: ...
 def groupby[KT, T](
-    key: typing.Callable[[T], KT] | typing.Any = ...,
+    key: collections.abc.Callable[[T], KT] | typing.Any = ...,
     seq: collections.abc.Iterable[T] = ...,
 ) -> (
     dict[KT, list[T]]
     | dict[typing.Any, list[T]]
-    | typing.Callable[..., dict[KT, list[T]] | dict[typing.Any, list[T]]]
+    | collections.abc.Callable[..., dict[KT, list[T]] | dict[typing.Any, list[T]]]
 ):
     """Curried version of groupby
 
@@ -720,13 +748,15 @@ def groupby[KT, T](
 # Curried interpose with explicit overloads for type safety
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def interpose[T]() -> typing.Callable[..., collections.abc.Iterator[T]]: ...
+def interpose[T]() -> collections.abc.Callable[..., collections.abc.Iterator[T]]: ...
 
 # Stage 1: Just el - returns callable waiting for seq
 @typing.overload
 def interpose[T](
     el: T, /
-) -> typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]: ...
+) -> collections.abc.Callable[
+    [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+]: ...
 
 # Stage 2: Full application - executes immediately
 @typing.overload
@@ -737,8 +767,10 @@ def interpose[T](
     el: T = ..., seq: collections.abc.Iterable[T] = ...
 ) -> (
     collections.abc.Iterator[T]
-    | typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]
-    | typing.Callable[..., collections.abc.Iterator[T]]
+    | collections.abc.Callable[
+        [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+    ]
+    | collections.abc.Callable[..., collections.abc.Iterator[T]]
 ):
     """Curried version of interpose
 
@@ -764,31 +796,31 @@ def interpose[T](
     ...
 
 @typing.overload
-def itemfilter[K, V]() -> typing.Callable[
+def itemfilter[K, V]() -> collections.abc.Callable[
     ..., dict[K, V] | collections.abc.MutableMapping[K, V]
 ]: ...
 
 # Stage 1a: Just predicate (no factory) - returns callable waiting for dict
 @typing.overload
 def itemfilter[K, V](
-    predicate: typing.Callable[[tuple[K, V]], bool], /
-) -> typing.Callable[[collections.abc.Mapping[K, V]], dict[K, V]]: ...
+    predicate: collections.abc.Callable[[tuple[K, V]], bool], /
+) -> collections.abc.Callable[[collections.abc.Mapping[K, V]], dict[K, V]]: ...
 
 # Stage 1b: Predicate with factory - returns callable waiting for dict
 @typing.overload
 def itemfilter[K, V](
-    predicate: typing.Callable[[tuple[K, V]], bool],
+    predicate: collections.abc.Callable[[tuple[K, V]], bool],
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> typing.Callable[
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+) -> collections.abc.Callable[
     [collections.abc.Mapping[K, V]], collections.abc.MutableMapping[K, V]
 ]: ...
 
 # Stage 2a: Full application (no factory) - executes immediately
 @typing.overload
 def itemfilter[K, V](
-    predicate: typing.Callable[[tuple[K, V]], bool],
+    predicate: collections.abc.Callable[[tuple[K, V]], bool],
     d: collections.abc.Mapping[K, V],
     /,
 ) -> dict[K, V]: ...
@@ -796,21 +828,21 @@ def itemfilter[K, V](
 # Stage 2b: Full application (with factory) - executes immediately
 @typing.overload
 def itemfilter[K, V](
-    predicate: typing.Callable[[tuple[K, V]], bool],
+    predicate: collections.abc.Callable[[tuple[K, V]], bool],
     d: collections.abc.Mapping[K, V],
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def itemfilter[K, V](
-    predicate: typing.Callable[[tuple[K, V]], bool] = ...,
+    predicate: collections.abc.Callable[[tuple[K, V]], bool] = ...,
     d: collections.abc.Mapping[K, V] = ...,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> (
     dict[K, V]
     | collections.abc.MutableMapping[K, V]
-    | typing.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]
+    | collections.abc.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]
 ):
     """Curried version of itemfilter
 
@@ -842,31 +874,31 @@ def itemfilter[K, V](
     ...
 
 @typing.overload
-def itemmap[K0, V0, K1, V1]() -> typing.Callable[
+def itemmap[K0, V0, K1, V1]() -> collections.abc.Callable[
     ..., dict[K1, V1] | collections.abc.MutableMapping[K1, V1]
 ]: ...
 
 # Stage 1a: Just func (no factory) - returns callable waiting for dict
 @typing.overload
 def itemmap[K0, V0, K1, V1](
-    func: typing.Callable[[tuple[K0, V0]], tuple[K1, V1]], /
-) -> typing.Callable[[collections.abc.Mapping[K0, V0]], dict[K1, V1]]: ...
+    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]], /
+) -> collections.abc.Callable[[collections.abc.Mapping[K0, V0]], dict[K1, V1]]: ...
 
 # Stage 1b: Func with factory - returns callable waiting for dict
 @typing.overload
 def itemmap[K0, V0, K1, V1](
-    func: typing.Callable[[tuple[K0, V0]], tuple[K1, V1]],
+    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, V1]],
-) -> typing.Callable[
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
+) -> collections.abc.Callable[
     [collections.abc.Mapping[K0, V0]], collections.abc.MutableMapping[K1, V1]
 ]: ...
 
 # Stage 2a: Full application (no factory) - executes immediately
 @typing.overload
 def itemmap[K0, V0, K1, V1](
-    func: typing.Callable[[tuple[K0, V0]], tuple[K1, V1]],
+    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: collections.abc.Mapping[K0, V0],
     /,
 ) -> dict[K1, V1]: ...
@@ -874,21 +906,25 @@ def itemmap[K0, V0, K1, V1](
 # Stage 2b: Full application (with factory) - executes immediately
 @typing.overload
 def itemmap[K0, V0, K1, V1](
-    func: typing.Callable[[tuple[K0, V0]], tuple[K1, V1]],
+    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: collections.abc.Mapping[K0, V0],
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, V1]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 def itemmap[K0, V0, K1, V1](
-    func: typing.Callable[[tuple[K0, V0]], tuple[K1, V1]] = ...,
+    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]] = ...,
     d: collections.abc.Mapping[K0, V0] = ...,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, V1]] = dict,
+    factory: collections.abc.Callable[
+        [], collections.abc.MutableMapping[K1, V1]
+    ] = dict,
 ) -> (
     dict[K1, V1]
     | collections.abc.MutableMapping[K1, V1]
-    | typing.Callable[..., dict[K1, V1] | collections.abc.MutableMapping[K1, V1]]
+    | collections.abc.Callable[
+        ..., dict[K1, V1] | collections.abc.MutableMapping[K1, V1]
+    ]
 ):
     """Curried version of itemmap
 
@@ -919,25 +955,25 @@ def itemmap[K0, V0, K1, V1](
 # Curried iterate with explicit overloads for type safety
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def iterate[T]() -> typing.Callable[..., collections.abc.Iterator[T]]: ...
+def iterate[T]() -> collections.abc.Callable[..., collections.abc.Iterator[T]]: ...
 
 # Stage 1: Just func - returns callable waiting for x
 @typing.overload
 def iterate[T](
-    func: typing.Callable[[T], T], /
-) -> typing.Callable[[T], collections.abc.Iterator[T]]: ...
+    func: collections.abc.Callable[[T], T], /
+) -> collections.abc.Callable[[T], collections.abc.Iterator[T]]: ...
 
 # Stage 2: Full application - executes immediately
 @typing.overload
 def iterate[T](
-    func: typing.Callable[[T], T], x: T, /
+    func: collections.abc.Callable[[T], T], x: T, /
 ) -> collections.abc.Iterator[T]: ...
 def iterate[T](
-    func: typing.Callable[[T], T] = ..., x: T = ...
+    func: collections.abc.Callable[[T], T] = ..., x: T = ...
 ) -> (
     collections.abc.Iterator[T]
-    | typing.Callable[[T], collections.abc.Iterator[T]]
-    | typing.Callable[..., collections.abc.Iterator[T]]
+    | collections.abc.Callable[[T], collections.abc.Iterator[T]]
+    | collections.abc.Callable[..., collections.abc.Iterator[T]]
 ):
     """Curried version of iterate
 
@@ -979,21 +1015,23 @@ def iterate[T](
 # Curried join with explicit overloads for type safety
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def join[T, U]() -> typing.Callable[..., collections.abc.Iterator[tuple[T, U]]]: ...
+def join[T, U]() -> collections.abc.Callable[
+    ..., collections.abc.Iterator[tuple[T, U]]
+]: ...
 
 # Stage 1: Just leftkey - returns a callable
 @typing.overload
 def join[T, U](
-    leftkey: typing.Callable[[T], typing.Hashable], /
-) -> typing.Callable[..., collections.abc.Iterator[tuple[T, U]]]: ...
+    leftkey: collections.abc.Callable[[T], typing.Hashable], /
+) -> collections.abc.Callable[..., collections.abc.Iterator[tuple[T, U]]]: ...
 
 # Stage 2: leftkey + leftseq - returns a callable
 @typing.overload
 def join[T, U](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
     /,
-) -> typing.Callable[..., collections.abc.Iterator[tuple[T, U]]]: ...
+) -> collections.abc.Callable[..., collections.abc.Iterator[tuple[T, U]]]: ...
 
 # Stage 3: leftkey + leftseq + rightkey - returns callable waiting for rightseq
 # This is the key overload for pipe usage!
@@ -1001,11 +1039,11 @@ def join[T, U](
 # The callable will properly infer types when called with rightseq.
 @typing.overload
 def join[T](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[..., typing.Hashable],
+    rightkey: collections.abc.Callable[..., typing.Hashable],
     /,
-) -> typing.Callable[
+) -> collections.abc.Callable[
     [collections.abc.Iterable[typing.Any]],
     collections.abc.Iterator[tuple[T, typing.Any]],
 ]: ...
@@ -1013,9 +1051,9 @@ def join[T](
 # Stage 4a: Full application (inner join) - executes immediately
 @typing.overload
 def join[T, U](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable],
+    rightkey: collections.abc.Callable[[U], typing.Hashable],
     rightseq: collections.abc.Iterable[U],
     /,
 ) -> collections.abc.Iterator[tuple[T, U]]: ...
@@ -1023,9 +1061,9 @@ def join[T, U](
 # Stage 4b: Full application with left_default only (right outer join)
 @typing.overload
 def join[T, U, L](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable],
+    rightkey: collections.abc.Callable[[U], typing.Hashable],
     rightseq: collections.abc.Iterable[U],
     /,
     left_default: L,
@@ -1034,9 +1072,9 @@ def join[T, U, L](
 # Stage 4c: Full application with right_default only (left outer join)
 @typing.overload
 def join[T, U, R](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable],
+    rightkey: collections.abc.Callable[[U], typing.Hashable],
     rightseq: collections.abc.Iterable[U],
     /,
     *,
@@ -1046,9 +1084,9 @@ def join[T, U, R](
 # Stage 4d: Full application with both defaults (full outer join)
 @typing.overload
 def join[T, U, L, R](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable],
+    rightkey: collections.abc.Callable[[U], typing.Hashable],
     rightseq: collections.abc.Iterable[U],
     /,
     left_default: L,
@@ -1058,27 +1096,27 @@ def join[T, U, L, R](
 # Stage 3 with defaults: leftkey + leftseq + rightkey + defaults - returns callable
 @typing.overload
 def join[T, U, L, R](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable],
+    rightkey: collections.abc.Callable[[U], typing.Hashable],
     /,
     left_default: L,
     right_default: R,
-) -> typing.Callable[
+) -> collections.abc.Callable[
     [collections.abc.Iterable[U]], collections.abc.Iterator[tuple[T | L, U | R]]
 ]: ...
 
 # Implementation signature
 def join[T, U, L, R](
-    leftkey: typing.Callable[[T], typing.Hashable] | typing.Hashable = ...,
+    leftkey: collections.abc.Callable[[T], typing.Hashable] | typing.Hashable = ...,
     leftseq: collections.abc.Iterable[T] = ...,
-    rightkey: typing.Callable[[U], typing.Hashable] | typing.Hashable = ...,
+    rightkey: collections.abc.Callable[[U], typing.Hashable] | typing.Hashable = ...,
     rightseq: collections.abc.Iterable[U] = ...,
     left_default: L = ...,
     right_default: R = ...,
 ) -> (
     collections.abc.Iterator[tuple[T | L, U | R]]
-    | typing.Callable[..., collections.abc.Iterator[tuple[T | L, U | R]]]
+    | collections.abc.Callable[..., collections.abc.Iterator[tuple[T | L, U | R]]]
 ):
     """Curried version of join
 
@@ -1110,31 +1148,31 @@ def join[T, U, L, R](
 # Curried keyfilter with explicit overloads for type safety
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def keyfilter[K, V]() -> typing.Callable[
+def keyfilter[K, V]() -> collections.abc.Callable[
     ..., dict[K, V] | collections.abc.MutableMapping[K, V]
 ]: ...
 
 # Stage 1a: Just predicate (no factory) - returns callable waiting for dict
 @typing.overload
 def keyfilter[K, V](
-    predicate: typing.Callable[[K], bool], /
-) -> typing.Callable[[collections.abc.Mapping[K, V]], dict[K, V]]: ...
+    predicate: collections.abc.Callable[[K], bool], /
+) -> collections.abc.Callable[[collections.abc.Mapping[K, V]], dict[K, V]]: ...
 
 # Stage 1b: Predicate with factory - returns callable waiting for dict
 @typing.overload
 def keyfilter[K, V](
-    predicate: typing.Callable[[K], bool],
+    predicate: collections.abc.Callable[[K], bool],
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> typing.Callable[
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+) -> collections.abc.Callable[
     [collections.abc.Mapping[K, V]], collections.abc.MutableMapping[K, V]
 ]: ...
 
 # Stage 2a: Full application (no factory) - executes immediately
 @typing.overload
 def keyfilter[K, V](
-    predicate: typing.Callable[[K], bool],
+    predicate: collections.abc.Callable[[K], bool],
     d: collections.abc.Mapping[K, V],
     /,
 ) -> dict[K, V]: ...
@@ -1142,21 +1180,21 @@ def keyfilter[K, V](
 # Stage 2b: Full application (with factory) - executes immediately
 @typing.overload
 def keyfilter[K, V](
-    predicate: typing.Callable[[K], bool],
+    predicate: collections.abc.Callable[[K], bool],
     d: collections.abc.Mapping[K, V],
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def keyfilter[K, V](
-    predicate: typing.Callable[[K], bool] = ...,
+    predicate: collections.abc.Callable[[K], bool] = ...,
     d: collections.abc.Mapping[K, V] = ...,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> (
     dict[K, V]
     | collections.abc.MutableMapping[K, V]
-    | typing.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]
+    | collections.abc.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]
 ):
     """Curried version of keyfilter
 
@@ -1187,31 +1225,31 @@ def keyfilter[K, V](
     ...
 
 @typing.overload
-def keymap[K0, K1, V]() -> typing.Callable[
+def keymap[K0, K1, V]() -> collections.abc.Callable[
     ..., dict[K1, V] | collections.abc.MutableMapping[K1, V]
 ]: ...
 
 # Stage 1a: Just func (no factory) - returns callable waiting for dict
 @typing.overload
 def keymap[K0, K1, V](
-    func: typing.Callable[[K0], K1], /
-) -> typing.Callable[[collections.abc.Mapping[K0, V]], dict[K1, V]]: ...
+    func: collections.abc.Callable[[K0], K1], /
+) -> collections.abc.Callable[[collections.abc.Mapping[K0, V]], dict[K1, V]]: ...
 
 # Stage 1b: Func with factory - returns callable waiting for dict
 @typing.overload
 def keymap[K0, K1, V](
-    func: typing.Callable[[K0], K1],
+    func: collections.abc.Callable[[K0], K1],
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, V]],
-) -> typing.Callable[
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
+) -> collections.abc.Callable[
     [collections.abc.Mapping[K0, V]], collections.abc.MutableMapping[K1, V]
 ]: ...
 
 # Stage 2a: Full application (no factory) - executes immediately
 @typing.overload
 def keymap[K0, K1, V](
-    func: typing.Callable[[K0], K1],
+    func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
     /,
 ) -> dict[K1, V]: ...
@@ -1219,21 +1257,21 @@ def keymap[K0, K1, V](
 # Stage 2b: Full application (with factory) - executes immediately
 @typing.overload
 def keymap[K0, K1, V](
-    func: typing.Callable[[K0], K1],
+    func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 def keymap[K0, K1, V](
-    func: typing.Callable[[K0], K1] = ...,
+    func: collections.abc.Callable[[K0], K1] = ...,
     d: collections.abc.Mapping[K0, V] = ...,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
 ) -> (
     dict[K1, V]
     | collections.abc.MutableMapping[K1, V]
-    | typing.Callable[..., dict[K1, V] | collections.abc.MutableMapping[K1, V]]
+    | collections.abc.Callable[..., dict[K1, V] | collections.abc.MutableMapping[K1, V]]
 ):
     """Curried version of keymap
 
@@ -1262,24 +1300,28 @@ def keymap[K0, K1, V](
     ...
 
 @typing.overload
-def map[T1, S]() -> typing.Callable[
-    ..., collections.abc.Iterator[S] | typing.Callable[..., collections.abc.Iterator[S]]
+def map[T1, S]() -> collections.abc.Callable[
+    ...,
+    collections.abc.Iterator[S]
+    | collections.abc.Callable[..., collections.abc.Iterator[S]],
 ]: ...
 @typing.overload
 def map[T1, S](
-    func: typing.Callable[[T1], S], /
-) -> typing.Callable[[collections.abc.Iterable[T1]], collections.abc.Iterator[S]]: ...
+    func: collections.abc.Callable[[T1], S], /
+) -> collections.abc.Callable[
+    [collections.abc.Iterable[T1]], collections.abc.Iterator[S]
+]: ...
 @typing.overload
 def map[T1, T2, S](
-    func: typing.Callable[[T1, T2], S], /
-) -> typing.Callable[
+    func: collections.abc.Callable[[T1, T2], S], /
+) -> collections.abc.Callable[
     [collections.abc.Iterable[T1], collections.abc.Iterable[T2]],
     collections.abc.Iterator[S],
 ]: ...
 @typing.overload
 def map[T1, T2, T3, S](
-    func: typing.Callable[[T1, T2, T3], S], /
-) -> typing.Callable[
+    func: collections.abc.Callable[[T1, T2, T3], S], /
+) -> collections.abc.Callable[
     [
         collections.abc.Iterable[T1],
         collections.abc.Iterable[T2],
@@ -1289,8 +1331,8 @@ def map[T1, T2, T3, S](
 ]: ...
 @typing.overload
 def map[T1, T2, T3, T4, S](
-    func: typing.Callable[[T1, T2, T3, T4], S], /
-) -> typing.Callable[
+    func: collections.abc.Callable[[T1, T2, T3, T4], S], /
+) -> collections.abc.Callable[
     [
         collections.abc.Iterable[T1],
         collections.abc.Iterable[T2],
@@ -1301,8 +1343,8 @@ def map[T1, T2, T3, T4, S](
 ]: ...
 @typing.overload
 def map[T1, T2, T3, T4, T5, S](
-    func: typing.Callable[[T1, T2, T3, T4, T5], S], /
-) -> typing.Callable[
+    func: collections.abc.Callable[[T1, T2, T3, T4, T5], S], /
+) -> collections.abc.Callable[
     [
         collections.abc.Iterable[T1],
         collections.abc.Iterable[T2],
@@ -1314,18 +1356,18 @@ def map[T1, T2, T3, T4, T5, S](
 ]: ...
 @typing.overload
 def map[T1, S](
-    func: typing.Callable[[T1], S], iterable: collections.abc.Iterable[T1], /
+    func: collections.abc.Callable[[T1], S], iterable: collections.abc.Iterable[T1], /
 ) -> collections.abc.Iterator[S]: ...
 @typing.overload
 def map[T1, T2, S](
-    func: typing.Callable[[T1, T2], S],
+    func: collections.abc.Callable[[T1, T2], S],
     iterable: collections.abc.Iterable[T1],
     iter2: collections.abc.Iterable[T2],
     /,
 ) -> collections.abc.Iterator[S]: ...
 @typing.overload
 def map[T1, T2, T3, S](
-    func: typing.Callable[[T1, T2, T3], S],
+    func: collections.abc.Callable[[T1, T2, T3], S],
     iterable: collections.abc.Iterable[T1],
     iter2: collections.abc.Iterable[T2],
     iter3: collections.abc.Iterable[T3],
@@ -1333,7 +1375,7 @@ def map[T1, T2, T3, S](
 ) -> collections.abc.Iterator[S]: ...
 @typing.overload
 def map[T1, T2, T3, T4, S](
-    func: typing.Callable[[T1, T2, T3, T4], S],
+    func: collections.abc.Callable[[T1, T2, T3, T4], S],
     iterable: collections.abc.Iterable[T1],
     iter2: collections.abc.Iterable[T2],
     iter3: collections.abc.Iterable[T3],
@@ -1342,7 +1384,7 @@ def map[T1, T2, T3, T4, S](
 ) -> collections.abc.Iterator[S]: ...
 @typing.overload
 def map[T1, T2, T3, T4, T5, S](
-    func: typing.Callable[[T1, T2, T3, T4, T5], S],
+    func: collections.abc.Callable[[T1, T2, T3, T4, T5], S],
     iterable: collections.abc.Iterable[T1],
     iter2: collections.abc.Iterable[T2],
     iter3: collections.abc.Iterable[T3],
@@ -1352,7 +1394,7 @@ def map[T1, T2, T3, T4, T5, S](
 ) -> collections.abc.Iterator[S]: ...
 @typing.overload
 def map[S](
-    func: typing.Callable[..., S],
+    func: collections.abc.Callable[..., S],
     iterable: collections.abc.Iterable[typing.Any],
     iter2: collections.abc.Iterable[typing.Any],
     iter3: collections.abc.Iterable[typing.Any],
@@ -1363,14 +1405,15 @@ def map[S](
     *iterables: collections.abc.Iterable[typing.Any],
 ) -> collections.abc.Iterator[S]: ...
 def map[S](
-    func: typing.Callable[..., S] = ...,
+    func: collections.abc.Callable[..., S] = ...,
     *iterables: collections.abc.Iterable[typing.Any],
 ) -> (
     collections.abc.Iterator[S]
-    | typing.Callable[..., collections.abc.Iterator[S]]
-    | typing.Callable[
+    | collections.abc.Callable[..., collections.abc.Iterator[S]]
+    | collections.abc.Callable[
         ...,
-        collections.abc.Iterator[S] | typing.Callable[..., collections.abc.Iterator[S]],
+        collections.abc.Iterator[S]
+        | collections.abc.Callable[..., collections.abc.Iterator[S]],
     ]
 ):
     """Curried version of builtin map function
@@ -1395,28 +1438,35 @@ def map[S](
     ...
 
 @typing.overload
-def mapcat[T, R]() -> typing.Callable[
-    ..., collections.abc.Iterator[R] | typing.Callable[..., collections.abc.Iterator[R]]
+def mapcat[T, R]() -> collections.abc.Callable[
+    ...,
+    collections.abc.Iterator[R]
+    | collections.abc.Callable[..., collections.abc.Iterator[R]],
 ]: ...
 @typing.overload
 def mapcat[T, R](
-    func: typing.Callable[[T], collections.abc.Iterable[R]], /
-) -> typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[R]]: ...
+    func: collections.abc.Callable[[T], collections.abc.Iterable[R]], /
+) -> collections.abc.Callable[
+    [collections.abc.Iterable[T]], collections.abc.Iterator[R]
+]: ...
 @typing.overload
 def mapcat[T, R](
-    func: typing.Callable[[T], collections.abc.Iterable[R]],
+    func: collections.abc.Callable[[T], collections.abc.Iterable[R]],
     seqs: collections.abc.Iterable[T],
     /,
 ) -> collections.abc.Iterator[R]: ...
 def mapcat[T, R](
-    func: typing.Callable[[T], collections.abc.Iterable[R]] = ...,
+    func: collections.abc.Callable[[T], collections.abc.Iterable[R]] = ...,
     seqs: collections.abc.Iterable[T] = ...,
 ) -> (
     collections.abc.Iterator[R]
-    | typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[R]]
-    | typing.Callable[
+    | collections.abc.Callable[
+        [collections.abc.Iterable[T]], collections.abc.Iterator[R]
+    ]
+    | collections.abc.Callable[
         ...,
-        collections.abc.Iterator[R] | typing.Callable[..., collections.abc.Iterator[R]],
+        collections.abc.Iterator[R]
+        | collections.abc.Callable[..., collections.abc.Iterator[R]],
     ]
 ):
     """Curried version of mapcat
@@ -1438,18 +1488,22 @@ def mapcat[T, R](
 # Curried nth with explicit overloads for type safety
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def nth[T]() -> typing.Callable[..., T]: ...
+def nth[T]() -> collections.abc.Callable[..., T]: ...
 
 # Stage 1: Just n - returns callable waiting for seq
 @typing.overload
-def nth[T](n: int, /) -> typing.Callable[[collections.abc.Iterable[T]], T]: ...
+def nth[T](n: int, /) -> collections.abc.Callable[[collections.abc.Iterable[T]], T]: ...
 
 # Stage 2: Full application - executes immediately
 @typing.overload
 def nth[T](n: int, seq: collections.abc.Iterable[T], /) -> T: ...
 def nth[T](
     n: int = ..., seq: collections.abc.Iterable[T] = ...
-) -> T | typing.Callable[[collections.abc.Iterable[T]], T] | typing.Callable[..., T]:
+) -> (
+    T
+    | collections.abc.Callable[[collections.abc.Iterable[T]], T]
+    | collections.abc.Callable[..., T]
+):
     """Curried version of nth
 
     The nth element in a sequence.
@@ -1481,11 +1535,13 @@ def nth[T](
 partial = curry(functools.partial)
 
 @typing.overload
-def partition[T]() -> typing.Callable[..., collections.abc.Iterator[tuple[T, ...]]]: ...
+def partition[T]() -> collections.abc.Callable[
+    ..., collections.abc.Iterator[tuple[T, ...]]
+]: ...
 @typing.overload
 def partition[T](
     n: int, /
-) -> typing.Callable[..., collections.abc.Iterator[tuple[T, ...]]]: ...
+) -> collections.abc.Callable[..., collections.abc.Iterator[tuple[T, ...]]]: ...
 @typing.overload
 def partition[T](
     n: typing.Literal[1], seq: collections.abc.Iterable[T], /
@@ -1512,7 +1568,7 @@ def partition[T, P](
 ) -> (
     collections.abc.Iterator[tuple[T, ...]]
     | collections.abc.Iterator[tuple[T | P, ...]]
-    | typing.Callable[..., collections.abc.Iterator[tuple[T | P, ...]]]
+    | collections.abc.Callable[..., collections.abc.Iterator[tuple[T | P, ...]]]
 ):
     """Curried version of partition
 
@@ -1549,7 +1605,7 @@ def partition[T, P](
 # Curried partition_all with explicit overloads for type safety
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def partition_all[T]() -> typing.Callable[
+def partition_all[T]() -> collections.abc.Callable[
     ..., collections.abc.Iterator[tuple[T, ...]]
 ]: ...
 
@@ -1557,13 +1613,13 @@ def partition_all[T]() -> typing.Callable[
 @typing.overload
 def partition_all[T](
     n: typing.Literal[1], /
-) -> typing.Callable[
+) -> collections.abc.Callable[
     [collections.abc.Iterable[T]], collections.abc.Iterator[tuple[T]]
 ]: ...
 @typing.overload
 def partition_all[T](
     n: int, /
-) -> typing.Callable[
+) -> collections.abc.Callable[
     [collections.abc.Iterable[T]], collections.abc.Iterator[tuple[T, ...]]
 ]: ...
 
@@ -1580,11 +1636,11 @@ def partition_all[T](
     n: int = ..., seq: collections.abc.Iterable[T] = ...
 ) -> (
     collections.abc.Iterator[tuple[T, ...]]
-    | typing.Callable[
+    | collections.abc.Callable[
         [collections.abc.Iterable[T]],
         collections.abc.Iterator[tuple[T, ...]] | collections.abc.Iterator[tuple[T]],
     ]
-    | typing.Callable[..., collections.abc.Iterator[tuple[T, ...]]]
+    | collections.abc.Callable[..., collections.abc.Iterator[tuple[T, ...]]]
 ):
     """Curried version of partition_all
 
@@ -1619,14 +1675,14 @@ partitionby = curry(_recipes.partitionby)
 peekn = curry(_itertoolz.peekn)
 
 @typing.overload
-def pluck[T]() -> typing.Callable[
+def pluck[T]() -> collections.abc.Callable[
     ..., collections.abc.Iterator[T] | collections.abc.Iterator[tuple[T, ...]]
 ]: ...
 @typing.overload
 def pluck[T](
     ind: collections.abc.Sequence[typing.Any], /
 ) -> (
-    typing.Callable[
+    collections.abc.Callable[
         [
             collections.abc.Iterable[
                 collections.abc.Sequence[T] | collections.abc.Mapping[typing.Any, T]
@@ -1634,7 +1690,7 @@ def pluck[T](
         ],
         collections.abc.Iterator[tuple[T, ...]],
     ]
-    | typing.Callable[
+    | collections.abc.Callable[
         [
             collections.abc.Iterable[
                 collections.abc.Sequence[T] | collections.abc.Mapping[typing.Any, T]
@@ -1648,7 +1704,7 @@ def pluck[T](
 def pluck[T](
     ind: typing.Any, /
 ) -> (
-    typing.Callable[
+    collections.abc.Callable[
         [
             collections.abc.Iterable[
                 collections.abc.Sequence[T] | collections.abc.Mapping[typing.Any, T]
@@ -1656,7 +1712,7 @@ def pluck[T](
         ],
         collections.abc.Iterator[T],
     ]
-    | typing.Callable[
+    | collections.abc.Callable[
         [
             collections.abc.Iterable[
                 collections.abc.Sequence[T] | collections.abc.Mapping[typing.Any, T]
@@ -1709,7 +1765,7 @@ def pluck[T](
 ) -> (
     collections.abc.Iterator[T]
     | collections.abc.Iterator[tuple[T, ...]]
-    | typing.Callable[
+    | collections.abc.Callable[
         ..., collections.abc.Iterator[T] | collections.abc.Iterator[tuple[T, ...]]
     ]
 ):
@@ -1751,33 +1807,33 @@ def pluck[T](
 random_sample = curry(_itertoolz.random_sample)
 
 @typing.overload
-def reduce[T]() -> typing.Callable[..., T]: ...
+def reduce[T]() -> collections.abc.Callable[..., T]: ...
 @typing.overload
 def reduce[T](
-    function: typing.Callable[[T, T], T], /
-) -> typing.Callable[[collections.abc.Iterable[T]], T]: ...
+    function: collections.abc.Callable[[T, T], T], /
+) -> collections.abc.Callable[[collections.abc.Iterable[T]], T]: ...
 @typing.overload
 def reduce[T, S](
-    function: typing.Callable[[T, S], T], /
-) -> typing.Callable[..., T]: ...
+    function: collections.abc.Callable[[T, S], T], /
+) -> collections.abc.Callable[..., T]: ...
 @typing.overload
 def reduce[T](
-    function: typing.Callable[[T, T], T],
+    function: collections.abc.Callable[[T, T], T],
     iterable: collections.abc.Iterable[T],
     /,
 ) -> T: ...
 @typing.overload
 def reduce[T, S](
-    function: typing.Callable[[T, S], T],
+    function: collections.abc.Callable[[T, S], T],
     iterable: collections.abc.Iterable[S],
     initial: T,
     /,
 ) -> T: ...
 def reduce[T, S](
-    function: typing.Callable[[T, S], T] = ...,
+    function: collections.abc.Callable[[T, S], T] = ...,
     iterable: collections.abc.Iterable[S] = ...,
     initial: T = ...,
-) -> T | typing.Callable[..., T]:
+) -> T | collections.abc.Callable[..., T]:
     """Curried version of functools.reduce
 
     Apply a function of two arguments cumulatively to items of an iterable,
@@ -1804,25 +1860,30 @@ reduceby = curry(_itertoolz.reduceby)
 # Curried remove with explicit overloads for type safety
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def remove[T]() -> typing.Callable[..., collections.abc.Iterable[T]]: ...
+def remove[T]() -> collections.abc.Callable[..., collections.abc.Iterable[T]]: ...
 
 # Stage 1: Just predicate - returns callable waiting for seq
 @typing.overload
 def remove[T](
-    predicate: typing.Callable[[T], bool], /
-) -> typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterable[T]]: ...
+    predicate: collections.abc.Callable[[T], bool], /
+) -> collections.abc.Callable[
+    [collections.abc.Iterable[T]], collections.abc.Iterable[T]
+]: ...
 
 # Stage 2: Full application - executes immediately
 @typing.overload
 def remove[T](
-    predicate: typing.Callable[[T], bool], seq: collections.abc.Iterable[T], /
+    predicate: collections.abc.Callable[[T], bool], seq: collections.abc.Iterable[T], /
 ) -> collections.abc.Iterable[T]: ...
 def remove[T](
-    predicate: typing.Callable[[T], bool] = ..., seq: collections.abc.Iterable[T] = ...
+    predicate: collections.abc.Callable[[T], bool] = ...,
+    seq: collections.abc.Iterable[T] = ...,
 ) -> (
     collections.abc.Iterable[T]
-    | typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterable[T]]
-    | typing.Callable[..., collections.abc.Iterable[T]]
+    | collections.abc.Callable[
+        [collections.abc.Iterable[T]], collections.abc.Iterable[T]
+    ]
+    | collections.abc.Callable[..., collections.abc.Iterable[T]]
 ):
     """Curried version of remove
 
@@ -1851,7 +1912,7 @@ def remove[T](
 # Curried sliding_window with explicit overloads for type safety
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def sliding_window[T]() -> typing.Callable[
+def sliding_window[T]() -> collections.abc.Callable[
     ..., collections.abc.Iterator[tuple[T, ...]]
 ]: ...
 
@@ -1859,7 +1920,7 @@ def sliding_window[T]() -> typing.Callable[
 @typing.overload
 def sliding_window[T](
     n: typing.Literal[1], /
-) -> typing.Callable[
+) -> collections.abc.Callable[
     [collections.abc.Iterable[T]], collections.abc.Iterator[tuple[T]]
 ]: ...
 
@@ -1867,7 +1928,7 @@ def sliding_window[T](
 @typing.overload
 def sliding_window[T](
     n: typing.Literal[2], /
-) -> typing.Callable[
+) -> collections.abc.Callable[
     [collections.abc.Iterable[T]], collections.abc.Iterator[tuple[T, T]]
 ]: ...
 
@@ -1875,7 +1936,7 @@ def sliding_window[T](
 @typing.overload
 def sliding_window[T](
     n: typing.Literal[3], /
-) -> typing.Callable[
+) -> collections.abc.Callable[
     [collections.abc.Iterable[T]], collections.abc.Iterator[tuple[T, T, T]]
 ]: ...
 
@@ -1883,7 +1944,7 @@ def sliding_window[T](
 @typing.overload
 def sliding_window[T](
     n: int, /
-) -> typing.Callable[
+) -> collections.abc.Callable[
     [collections.abc.Iterable[T]], collections.abc.Iterator[tuple[T, ...]]
 ]: ...
 
@@ -1914,10 +1975,10 @@ def sliding_window[T](
     n: int = ..., seq: collections.abc.Iterable[T] = ...
 ) -> (
     collections.abc.Iterator[tuple[T, ...]]
-    | typing.Callable[
+    | collections.abc.Callable[
         [collections.abc.Iterable[T]], collections.abc.Iterator[tuple[T, ...]]
     ]
-    | typing.Callable[..., collections.abc.Iterator[tuple[T, ...]]]
+    | collections.abc.Callable[..., collections.abc.Iterator[tuple[T, ...]]]
 ):
     """Curried version of sliding_window
 
@@ -1948,7 +2009,7 @@ def sliding_window[T](
 # Note: key and reverse are keyword-only parameters in builtin sorted
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def sorted[T]() -> typing.Callable[..., list[T]]: ...
+def sorted[T]() -> collections.abc.Callable[..., list[T]]: ...
 
 # Stage 1a: Partial application with keyword args only (no key) - returns callable
 @typing.overload
@@ -1993,7 +2054,7 @@ def sorted[T](
     *,
     key: collections.abc.Callable[[T], SupportsRichComparison] | None = None,
     reverse: bool = False,
-) -> list[T] | typing.Callable[..., list[T]]:
+) -> list[T] | collections.abc.Callable[..., list[T]]:
     """Curried version of builtin sorted
 
     Return a new sorted list from the items in iterable.
@@ -2029,13 +2090,15 @@ def sorted[T](
 # Curried tail with explicit overloads for type safety
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def tail[T]() -> typing.Callable[..., collections.abc.Iterator[T]]: ...
+def tail[T]() -> collections.abc.Callable[..., collections.abc.Iterator[T]]: ...
 
 # Stage 1: Just n - returns callable waiting for seq
 @typing.overload
 def tail[T](
     n: int, /
-) -> typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]: ...
+) -> collections.abc.Callable[
+    [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+]: ...
 
 # Stage 2: Full application - executes immediately
 @typing.overload
@@ -2046,8 +2109,10 @@ def tail[T](
     n: int = ..., seq: collections.abc.Iterable[T] = ...
 ) -> (
     collections.abc.Iterator[T]
-    | typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]
-    | typing.Callable[..., collections.abc.Iterator[T]]
+    | collections.abc.Callable[
+        [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+    ]
+    | collections.abc.Callable[..., collections.abc.Iterator[T]]
 ):
     """Curried version of tail
 
@@ -2075,11 +2140,13 @@ def tail[T](
     ...
 
 @typing.overload
-def take[T]() -> typing.Callable[..., collections.abc.Iterator[T]]: ...
+def take[T]() -> collections.abc.Callable[..., collections.abc.Iterator[T]]: ...
 @typing.overload
 def take[T](
     n: int, /
-) -> typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]: ...
+) -> collections.abc.Callable[
+    [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+]: ...
 @typing.overload
 def take[T](
     n: int, seq: collections.abc.Iterable[T], /
@@ -2088,8 +2155,10 @@ def take[T](
     n: int = ..., seq: collections.abc.Iterable[T] = ...
 ) -> (
     collections.abc.Iterator[T]
-    | typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]
-    | typing.Callable[..., collections.abc.Iterator[T]]
+    | collections.abc.Callable[
+        [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+    ]
+    | collections.abc.Callable[..., collections.abc.Iterator[T]]
 ):
     """Curried version of take
 
@@ -2119,13 +2188,15 @@ def take[T](
 # Curried take_nth with explicit overloads for type safety
 # Stage 0: No arguments - returns a callable
 @typing.overload
-def take_nth[T]() -> typing.Callable[..., collections.abc.Iterator[T]]: ...
+def take_nth[T]() -> collections.abc.Callable[..., collections.abc.Iterator[T]]: ...
 
 # Stage 1: Just n - returns callable waiting for seq
 @typing.overload
 def take_nth[T](
     n: int, /
-) -> typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]: ...
+) -> collections.abc.Callable[
+    [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+]: ...
 
 # Stage 2: Full application - executes immediately
 @typing.overload
@@ -2136,8 +2207,10 @@ def take_nth[T](
     n: int = ..., seq: collections.abc.Iterable[T] = ...
 ) -> (
     collections.abc.Iterator[T]
-    | typing.Callable[[collections.abc.Iterable[T]], collections.abc.Iterator[T]]
-    | typing.Callable[..., collections.abc.Iterator[T]]
+    | collections.abc.Callable[
+        [collections.abc.Iterable[T]], collections.abc.Iterator[T]
+    ]
+    | collections.abc.Callable[..., collections.abc.Iterator[T]]
 ):
     """Curried version of take_nth
 
@@ -2168,31 +2241,31 @@ unique = curry(_itertoolz.unique)
 update_in = curry(_dicttoolz.update_in)
 
 @typing.overload
-def valfilter[K, V]() -> typing.Callable[
+def valfilter[K, V]() -> collections.abc.Callable[
     ..., dict[K, V] | collections.abc.MutableMapping[K, V]
 ]: ...
 
 # Stage 1a: Just predicate (no factory) - returns callable waiting for dict
 @typing.overload
 def valfilter[K, V](
-    predicate: typing.Callable[[V], bool], /
-) -> typing.Callable[[collections.abc.Mapping[K, V]], dict[K, V]]: ...
+    predicate: collections.abc.Callable[[V], bool], /
+) -> collections.abc.Callable[[collections.abc.Mapping[K, V]], dict[K, V]]: ...
 
 # Stage 1b: Predicate with factory - returns callable waiting for dict
 @typing.overload
 def valfilter[K, V](
-    predicate: typing.Callable[[V], bool],
+    predicate: collections.abc.Callable[[V], bool],
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> typing.Callable[
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+) -> collections.abc.Callable[
     [collections.abc.Mapping[K, V]], collections.abc.MutableMapping[K, V]
 ]: ...
 
 # Stage 2a: Full application (no factory) - executes immediately
 @typing.overload
 def valfilter[K, V](
-    predicate: typing.Callable[[V], bool],
+    predicate: collections.abc.Callable[[V], bool],
     d: collections.abc.Mapping[K, V],
     /,
 ) -> dict[K, V]: ...
@@ -2200,21 +2273,21 @@ def valfilter[K, V](
 # Stage 2b: Full application (with factory) - executes immediately
 @typing.overload
 def valfilter[K, V](
-    predicate: typing.Callable[[V], bool],
+    predicate: collections.abc.Callable[[V], bool],
     d: collections.abc.Mapping[K, V],
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def valfilter[K, V](
-    predicate: typing.Callable[[V], bool] = ...,
+    predicate: collections.abc.Callable[[V], bool] = ...,
     d: collections.abc.Mapping[K, V] = ...,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> (
     dict[K, V]
     | collections.abc.MutableMapping[K, V]
-    | typing.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]
+    | collections.abc.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]
 ):
     """Curried version of valfilter
 
@@ -2245,31 +2318,31 @@ def valfilter[K, V](
     ...
 
 @typing.overload
-def valmap[K, V0, V1]() -> typing.Callable[
+def valmap[K, V0, V1]() -> collections.abc.Callable[
     ..., dict[K, V1] | collections.abc.MutableMapping[K, V1]
 ]: ...
 
 # Stage 1a: Just func (no factory) - returns callable waiting for dict
 @typing.overload
 def valmap[K, V0, V1](
-    func: typing.Callable[[V0], V1], /
-) -> typing.Callable[[collections.abc.Mapping[K, V0]], dict[K, V1]]: ...
+    func: collections.abc.Callable[[V0], V1], /
+) -> collections.abc.Callable[[collections.abc.Mapping[K, V0]], dict[K, V1]]: ...
 
 # Stage 1b: Func with factory - returns callable waiting for dict
 @typing.overload
 def valmap[K, V0, V1](
-    func: typing.Callable[[V0], V1],
+    func: collections.abc.Callable[[V0], V1],
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V1]],
-) -> typing.Callable[
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
+) -> collections.abc.Callable[
     [collections.abc.Mapping[K, V0]], collections.abc.MutableMapping[K, V1]
 ]: ...
 
 # Stage 2a: Full application (no factory) - executes immediately
 @typing.overload
 def valmap[K, V0, V1](
-    func: typing.Callable[[V0], V1],
+    func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
     /,
 ) -> dict[K, V1]: ...
@@ -2277,21 +2350,21 @@ def valmap[K, V0, V1](
 # Stage 2b: Full application (with factory) - executes immediately
 @typing.overload
 def valmap[K, V0, V1](
-    func: typing.Callable[[V0], V1],
+    func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V1]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 def valmap[K, V0, V1](
-    func: typing.Callable[[V0], V1] = ...,
+    func: collections.abc.Callable[[V0], V1] = ...,
     d: collections.abc.Mapping[K, V0] = ...,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
 ) -> (
     dict[K, V1]
     | collections.abc.MutableMapping[K, V1]
-    | typing.Callable[..., dict[K, V1] | collections.abc.MutableMapping[K, V1]]
+    | collections.abc.Callable[..., dict[K, V1] | collections.abc.MutableMapping[K, V1]]
 ):
     """Curried version of valmap
 

--- a/src/toolz-stubs/curried/exceptions.pyi
+++ b/src/toolz-stubs/curried/exceptions.pyi
@@ -4,22 +4,24 @@ import typing
 __all__ = ["merge", "merge_with"]
 
 @typing.overload
-def merge_with[K, V]() -> typing.Callable[
+def merge_with[K, V]() -> collections.abc.Callable[
     ..., dict[K, V] | collections.abc.MutableMapping[K, V]
 ]: ...
 @typing.overload
 def merge_with[K, V](
-    func: typing.Callable[[list[V]], V], /
-) -> typing.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]: ...
+    func: collections.abc.Callable[[list[V]], V], /
+) -> collections.abc.Callable[
+    ..., dict[K, V] | collections.abc.MutableMapping[K, V]
+]: ...
 @typing.overload
 def merge_with[K, V](
-    func: typing.Callable[[list[V]], V],
+    func: collections.abc.Callable[[list[V]], V],
     d: collections.abc.Mapping[K, V],
     /,
 ) -> dict[K, V]: ...
 @typing.overload
 def merge_with[K, V](
-    func: typing.Callable[[list[V]], V],
+    func: collections.abc.Callable[[list[V]], V],
     d: collections.abc.Mapping[K, V],
     d2: collections.abc.Mapping[K, V],
     /,
@@ -27,29 +29,29 @@ def merge_with[K, V](
 ) -> dict[K, V]: ...
 @typing.overload
 def merge_with[K, V](
-    func: typing.Callable[[list[V]], V],
+    func: collections.abc.Callable[[list[V]], V],
     d: collections.abc.Mapping[K, V],
     d2: collections.abc.Mapping[K, V],
     /,
     *dicts: collections.abc.Mapping[K, V],
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 @typing.overload
 def merge_with[K, V](
-    func: typing.Callable[[list[V]], V],
+    func: collections.abc.Callable[[list[V]], V],
     /,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> typing.Callable[..., collections.abc.MutableMapping[K, V]]: ...
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+) -> collections.abc.Callable[..., collections.abc.MutableMapping[K, V]]: ...
 def merge_with[K, V](
-    func: typing.Callable[[list[V]], V] = ...,
+    func: collections.abc.Callable[[list[V]], V] = ...,
     d: collections.abc.Mapping[K, V] = ...,
     *dicts: collections.abc.Mapping[K, V],
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = ...,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = ...,
 ) -> (
     dict[K, V]
     | collections.abc.MutableMapping[K, V]
-    | typing.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]
+    | collections.abc.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]
 ):
     """Merge dictionaries and apply function to combined values
 
@@ -68,7 +70,7 @@ def merge_with[K, V](
     ...
 
 @typing.overload
-def merge[K, V]() -> typing.Callable[
+def merge[K, V]() -> collections.abc.Callable[
     ..., dict[K, V] | collections.abc.MutableMapping[K, V]
 ]: ...
 @typing.overload
@@ -86,21 +88,21 @@ def merge[K, V](
     d2: collections.abc.Mapping[K, V],
     /,
     *dicts: collections.abc.Mapping[K, V],
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 @typing.overload
 def merge[K, V](
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> typing.Callable[..., collections.abc.MutableMapping[K, V]]: ...
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+) -> collections.abc.Callable[..., collections.abc.MutableMapping[K, V]]: ...
 def merge[K, V](
     d: collections.abc.Mapping[K, V] = ...,
     *dicts: collections.abc.Mapping[K, V],
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = ...,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = ...,
 ) -> (
     dict[K, V]
     | collections.abc.MutableMapping[K, V]
-    | typing.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]
+    | collections.abc.Callable[..., dict[K, V] | collections.abc.MutableMapping[K, V]]
 ):
     """Merge a collection of dictionaries
 

--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -29,11 +29,11 @@ def merge[K, V](*dicts: collections.abc.Mapping[K, V]) -> dict[K, V]: ...
 @typing.overload
 def merge[K, V](
     *dicts: collections.abc.Mapping[K, V],
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def merge[K, V](
     *dicts: collections.abc.Mapping[K, V],
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Merge a collection of dictionaries
 
@@ -52,19 +52,19 @@ def merge[K, V](
 
 @typing.overload
 def merge_with[K, V](
-    func: typing.Callable[[list[V]], V],
+    func: collections.abc.Callable[[list[V]], V],
     *dicts: collections.abc.Mapping[K, V],
 ) -> dict[K, V]: ...
 @typing.overload
 def merge_with[K, V](
-    func: typing.Callable[[list[V]], V],
+    func: collections.abc.Callable[[list[V]], V],
     *dicts: collections.abc.Mapping[K, V],
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def merge_with[K, V](
-    func: typing.Callable[[list[V]], V],
+    func: collections.abc.Callable[[list[V]], V],
     *dicts: collections.abc.Mapping[K, V],
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Merge dictionaries and apply function to combined values
 
@@ -84,21 +84,21 @@ def merge_with[K, V](
 
 @typing.overload
 def valmap[K, V0, V1](
-    func: typing.Callable[[V0], V1],
+    func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
 ) -> dict[K, V1]: ...
 @typing.overload
 def valmap[K, V0, V1](
-    func: typing.Callable[[V0], V1],
+    func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V1]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 def valmap[K, V0, V1](
-    func: typing.Callable[[V0], V1],
+    func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
 ) -> collections.abc.MutableMapping[K, V1]:
     """Apply function to values of dictionary
 
@@ -114,21 +114,21 @@ def valmap[K, V0, V1](
 
 @typing.overload
 def keymap[K0, K1, V](
-    func: typing.Callable[[K0], K1],
+    func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
 ) -> dict[K1, V]: ...
 @typing.overload
 def keymap[K0, K1, V](
-    func: typing.Callable[[K0], K1],
+    func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 def keymap[K0, K1, V](
-    func: typing.Callable[[K0], K1],
+    func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
 ) -> collections.abc.MutableMapping[K1, V]:
     """Apply function to keys of dictionary
 
@@ -144,21 +144,23 @@ def keymap[K0, K1, V](
 
 @typing.overload
 def itemmap[K0, V0, K1, V1](
-    func: typing.Callable[[tuple[K0, V0]], tuple[K1, V1]],
+    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: collections.abc.Mapping[K0, V0],
 ) -> dict[K1, V1]: ...
 @typing.overload
 def itemmap[K0, V0, K1, V1](
-    func: typing.Callable[[tuple[K0, V0]], tuple[K1, V1]],
+    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: collections.abc.Mapping[K0, V0],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, V1]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 def itemmap[K0, V0, K1, V1](
-    func: typing.Callable[[tuple[K0, V0]], tuple[K1, V1]],
+    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: collections.abc.Mapping[K0, V0],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, V1]] = dict,
+    factory: collections.abc.Callable[
+        [], collections.abc.MutableMapping[K1, V1]
+    ] = dict,
 ) -> collections.abc.MutableMapping[K1, V1]:
     """Apply function to items of dictionary
 
@@ -174,45 +176,46 @@ def itemmap[K0, V0, K1, V1](
 
 @typing.overload
 def valfilter[K, V, R](
-    predicate: typing.Callable[[V], TypeIs[R]],
+    predicate: collections.abc.Callable[[V], TypeIs[R]],
     d: collections.abc.Mapping[K, V],
 ) -> dict[K, R]: ...
 @typing.overload
 def valfilter[K, V, R](
-    predicate: typing.Callable[[V], typing.TypeGuard[R]],
+    predicate: collections.abc.Callable[[V], typing.TypeGuard[R]],
     d: collections.abc.Mapping[K, V],
 ) -> dict[K, R]: ...
 @typing.overload
 def valfilter[K, V](
-    predicate: typing.Callable[[V], bool],
+    predicate: collections.abc.Callable[[V], bool],
     d: collections.abc.Mapping[K, V],
 ) -> dict[K, V]: ...
 @typing.overload
 def valfilter[K, V, R](
-    predicate: typing.Callable[[V], TypeIs[R]],
+    predicate: collections.abc.Callable[[V], TypeIs[R]],
     d: collections.abc.Mapping[K, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, R]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, R]],
 ) -> collections.abc.MutableMapping[K, R]: ...
 @typing.overload
 def valfilter[K, V, R](
-    predicate: typing.Callable[[V], typing.TypeGuard[R]],
+    predicate: collections.abc.Callable[[V], typing.TypeGuard[R]],
     d: collections.abc.Mapping[K, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, R]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, R]],
 ) -> collections.abc.MutableMapping[K, R]: ...
 @typing.overload
 def valfilter[K, V](
-    predicate: typing.Callable[[V], bool],
+    predicate: collections.abc.Callable[[V], bool],
     d: collections.abc.Mapping[K, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def valfilter[K, V, R](
-    predicate: typing.Callable[[V], bool] | typing.Callable[[V], typing.TypeGuard[R]],
+    predicate: collections.abc.Callable[[V], bool]
+    | collections.abc.Callable[[V], typing.TypeGuard[R]],
     d: collections.abc.Mapping[K, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Filter items in dictionary by value
 
@@ -230,45 +233,46 @@ def valfilter[K, V, R](
 
 @typing.overload
 def keyfilter[K, V, R](
-    predicate: typing.Callable[[K], TypeIs[R]],
+    predicate: collections.abc.Callable[[K], TypeIs[R]],
     d: collections.abc.Mapping[K, V],
 ) -> dict[R, V]: ...
 @typing.overload
 def keyfilter[K, V, R](
-    predicate: typing.Callable[[K], typing.TypeGuard[R]],
+    predicate: collections.abc.Callable[[K], typing.TypeGuard[R]],
     d: collections.abc.Mapping[K, V],
 ) -> dict[R, V]: ...
 @typing.overload
 def keyfilter[K, V](
-    predicate: typing.Callable[[K], bool],
+    predicate: collections.abc.Callable[[K], bool],
     d: collections.abc.Mapping[K, V],
 ) -> dict[K, V]: ...
 @typing.overload
 def keyfilter[K, V, R](
-    predicate: typing.Callable[[K], TypeIs[R]],
+    predicate: collections.abc.Callable[[K], TypeIs[R]],
     d: collections.abc.Mapping[K, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[R, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[R, V]],
 ) -> collections.abc.MutableMapping[R, V]: ...
 @typing.overload
 def keyfilter[K, V, R](
-    predicate: typing.Callable[[K], typing.TypeGuard[R]],
+    predicate: collections.abc.Callable[[K], typing.TypeGuard[R]],
     d: collections.abc.Mapping[K, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[R, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[R, V]],
 ) -> collections.abc.MutableMapping[R, V]: ...
 @typing.overload
 def keyfilter[K, V](
-    predicate: typing.Callable[[K], bool],
+    predicate: collections.abc.Callable[[K], bool],
     d: collections.abc.Mapping[K, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def keyfilter[K, V, R](
-    predicate: typing.Callable[[K], bool] | typing.Callable[[K], typing.TypeGuard[R]],
+    predicate: collections.abc.Callable[[K], bool]
+    | collections.abc.Callable[[K], typing.TypeGuard[R]],
     d: collections.abc.Mapping[K, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Filter items in dictionary by key
 
@@ -286,46 +290,46 @@ def keyfilter[K, V, R](
 
 @typing.overload
 def itemfilter[K, V, K1, V1](
-    predicate: typing.Callable[[tuple[K, V]], TypeIs[tuple[K1, V1]]],
+    predicate: collections.abc.Callable[[tuple[K, V]], TypeIs[tuple[K1, V1]]],
     d: collections.abc.Mapping[K, V],
 ) -> dict[K1, V1]: ...
 @typing.overload
 def itemfilter[K, V, K1, V1](
-    predicate: typing.Callable[[tuple[K, V]], typing.TypeGuard[tuple[K1, V1]]],
+    predicate: collections.abc.Callable[[tuple[K, V]], typing.TypeGuard[tuple[K1, V1]]],
     d: collections.abc.Mapping[K, V],
 ) -> dict[K1, V1]: ...
 @typing.overload
 def itemfilter[K, V](
-    predicate: typing.Callable[[tuple[K, V]], bool],
+    predicate: collections.abc.Callable[[tuple[K, V]], bool],
     d: collections.abc.Mapping[K, V],
 ) -> dict[K, V]: ...
 @typing.overload
 def itemfilter[K, V, K1, V1](
-    predicate: typing.Callable[[tuple[K, V]], TypeIs[tuple[K1, V1]]],
+    predicate: collections.abc.Callable[[tuple[K, V]], TypeIs[tuple[K1, V1]]],
     d: collections.abc.Mapping[K, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, V1]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 @typing.overload
 def itemfilter[K, V, K1, V1](
-    predicate: typing.Callable[[tuple[K, V]], typing.TypeGuard[tuple[K1, V1]]],
+    predicate: collections.abc.Callable[[tuple[K, V]], typing.TypeGuard[tuple[K1, V1]]],
     d: collections.abc.Mapping[K, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, V1]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 @typing.overload
 def itemfilter[K, V](
-    predicate: typing.Callable[[tuple[K, V]], bool],
+    predicate: collections.abc.Callable[[tuple[K, V]], bool],
     d: collections.abc.Mapping[K, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def itemfilter[K, V, K1, V1](
-    predicate: typing.Callable[[tuple[K, V]], bool]
-    | typing.Callable[[tuple[K, V]], typing.TypeGuard[tuple[K1, V1]]],
+    predicate: collections.abc.Callable[[tuple[K, V]], bool]
+    | collections.abc.Callable[[tuple[K, V]], typing.TypeGuard[tuple[K1, V1]]],
     d: collections.abc.Mapping[K, V],
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Filter items in dictionary by item
 
@@ -356,14 +360,14 @@ def assoc[K, V](
     key: K,
     value: V,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def assoc[K, V](
     d: collections.abc.Mapping[K, V],
     key: K,
     value: V,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Return a new dict with new key value pair
 
@@ -385,12 +389,12 @@ def dissoc[K, V](
 def dissoc[K, V](
     d: collections.abc.Mapping[K, V],
     *keys: K,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def dissoc[K, V](
     d: collections.abc.Mapping[K, V],
     *keys: K,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Return a new dict with the given key(s) removed.
 
@@ -419,7 +423,9 @@ def assoc_in[K1, K2, V1, V2](
     keys: tuple[K1, K2],
     value: V2,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, typing.Any]],
+    factory: collections.abc.Callable[
+        [], collections.abc.MutableMapping[K1, typing.Any]
+    ],
 ) -> collections.abc.MutableMapping[K1, typing.Any]: ...
 
 # Overloads for nested dictionaries with tuple keys (3-level nesting)
@@ -439,7 +445,9 @@ def assoc_in[K1, K2, K3, V1, V2, V3](
     keys: tuple[K1, K2, K3],
     value: V3,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K1, typing.Any]],
+    factory: collections.abc.Callable[
+        [], collections.abc.MutableMapping[K1, typing.Any]
+    ],
 ) -> collections.abc.MutableMapping[K1, typing.Any]: ...
 
 # General overloads for backwards compatibility
@@ -455,14 +463,14 @@ def assoc_in[K, V](
     keys: collections.abc.Iterable[K] | K,
     value: V,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def assoc_in[K, V](
     d: collections.abc.Mapping[K, V],
     keys: collections.abc.Iterable[K] | K,
     value: V,
     *,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Return a new dict with new, potentially nested, key value pair
 
@@ -481,31 +489,31 @@ def assoc_in[K, V](
 def update_in[K, V](
     d: collections.abc.Mapping[K, V],
     keys: collections.abc.Iterable[K] | K,
-    func: typing.Callable[..., V],
+    func: collections.abc.Callable[..., V],
     default: typing.Any | None = None,
 ) -> dict[K, V]: ...
 @typing.overload
 def update_in[K, V](
     d: collections.abc.Mapping[K, V],
     keys: collections.abc.Iterable[K] | K,
-    func: typing.Callable[..., V],
+    func: collections.abc.Callable[..., V],
     default: typing.Any | None,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 @typing.overload
 def update_in[K, V](
     d: collections.abc.Mapping[K, V],
     keys: collections.abc.Iterable[K] | K,
-    func: typing.Callable[..., V],
+    func: collections.abc.Callable[..., V],
     default: typing.Any | None = None,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]: ...
 def update_in[K, V](
     d: collections.abc.Mapping[K, V],
     keys: collections.abc.Iterable[K] | K,
-    func: typing.Callable[..., V],
+    func: collections.abc.Callable[..., V],
     default: typing.Any | None = None,
-    factory: typing.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Update value in a (potentially) nested dictionary
 

--- a/src/toolz-stubs/functoolz.pyi
+++ b/src/toolz-stubs/functoolz.pyi
@@ -25,9 +25,9 @@ PYPY = bool
 ### Internal type stubs
 _T = typing.TypeVar("_T")
 _Instance = typing.TypeVar("_Instance")
-_Getter = typing.Callable[[_Instance], _T]
-_Setter = typing.Callable[[_Instance, _T], None]
-_Deleter = typing.Callable[[_Instance], None]
+_Getter = collections.abc.Callable[[_Instance], _T]
+_Setter = collections.abc.Callable[[_Instance, _T], None]
+_Deleter = collections.abc.Callable[[_Instance], None]
 _InstancePropertyState = tuple[
     _Getter[_Instance, _T] | None,
     _Setter[_Instance, _T] | None,
@@ -46,7 +46,9 @@ def identity[T](x: T) -> T:
     """
     ...
 
-def apply[**P, T](func: typing.Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+def apply[**P, T](
+    func: collections.abc.Callable[P, T], *args: P.args, **kwargs: P.kwargs
+) -> T:
     """Applies a function and returns the results
 
     >>> def double(x): return 2*x
@@ -60,7 +62,9 @@ def apply[**P, T](func: typing.Callable[P, T], *args: P.args, **kwargs: P.kwargs
     ...
 
 def thread_first[T, R](
-    val: T, *forms: typing.Callable[[T], R] | tuple[typing.Callable[..., R], typing.Any]
+    val: T,
+    *forms: collections.abc.Callable[[T], R]
+    | tuple[collections.abc.Callable[..., R], typing.Any],
 ) -> R:
     """Thread value through a sequence of functions/forms
 
@@ -88,7 +92,8 @@ def thread_first[T, R](
     ...
 
 def thread_last[T, U](
-    val: T, *forms: typing.Callable[[T], U] | tuple[typing.Callable[..., U]]
+    val: T,
+    *forms: collections.abc.Callable[[T], U] | tuple[collections.abc.Callable[..., U]],
 ) -> U:
     """Thread value through a sequence of functions/forms
 
@@ -161,7 +166,9 @@ def instanceproperty(
     fdel: _Deleter[_Instance] | None = ...,
     doc: str | None = ...,
     classval: _T | None = ...,
-) -> typing.Callable[[_Getter[_Instance, _T]], InstanceProperty[_Instance, _T]]: ...
+) -> collections.abc.Callable[
+    [_Getter[_Instance, _T]], InstanceProperty[_Instance, _T]
+]: ...
 def instanceproperty(
     fget: _Getter[_Instance, _T] | None = None,
     fset: _Setter[_Instance, _T] | None = None,
@@ -170,7 +177,9 @@ def instanceproperty(
     classval: _T | None = None,
 ) -> (
     InstanceProperty[_Instance, _T]
-    | typing.Callable[[_Getter[_Instance, _T]], InstanceProperty[_Instance, _T]]
+    | collections.abc.Callable[
+        [_Getter[_Instance, _T]], InstanceProperty[_Instance, _T]
+    ]
 ):
     """Like @property, but returns ``classval`` when used as a class attribute
 
@@ -227,13 +236,13 @@ class curry[**P, T]:
     """
     def __init__(
         self,
-        func: curry[P, T] | functools.partial[T] | typing.Callable[P, T],
+        func: curry[P, T] | functools.partial[T] | collections.abc.Callable[P, T],
         /,  # Must be positional-only
         *args: typing.Any,
         **kwargs: typing.Any,
     ) -> None: ...
     @instanceproperty
-    def func(self) -> typing.Callable[P, T]: ...
+    def func(self) -> collections.abc.Callable[P, T]: ...
     @instanceproperty
     def __signature__(self) -> inspect.Signature: ...
     @instanceproperty
@@ -264,17 +273,17 @@ class curry[**P, T]:
     @typing.override
     def __reduce__(
         self,
-    ) -> tuple[typing.Callable[..., T], _CurryState]: ...
+    ) -> tuple[collections.abc.Callable[..., T], _CurryState]: ...
 
 @curry
 def memoize[T](
-    func: typing.Callable[..., T],
+    func: collections.abc.Callable[..., T],
     cache: dict[typing.Any, T] | None = None,
-    key: typing.Callable[
+    key: collections.abc.Callable[
         [tuple[typing.Any, ...], collections.abc.Mapping[str, typing.Any]], typing.Any
     ]
     | None = None,
-) -> typing.Callable[..., T]:
+) -> collections.abc.Callable[..., T]:
     """Cache a function's result for speedy future evaluation
 
     Considerations:
@@ -313,48 +322,50 @@ def memoize[T](
     ...
 
 @typing.overload
-def compose[**P, T](fn_0: typing.Callable[P, T]) -> typing.Callable[P, T]: ...
+def compose[**P, T](
+    fn_0: collections.abc.Callable[P, T],
+) -> collections.abc.Callable[P, T]: ...
 @typing.overload
 def compose[**P, T0, T1](
-    fn_0: typing.Callable[[T0], T1], fn_1: typing.Callable[P, T0]
-) -> typing.Callable[P, T1]: ...
+    fn_0: collections.abc.Callable[[T0], T1], fn_1: collections.abc.Callable[P, T0]
+) -> collections.abc.Callable[P, T1]: ...
 @typing.overload
 def compose[**P, T0, T1, T2](
-    fn_0: typing.Callable[[T1], T2],
-    fn_1: typing.Callable[[T0], T1],
-    fn_2: typing.Callable[P, T0],
-) -> typing.Callable[P, T2]: ...
+    fn_0: collections.abc.Callable[[T1], T2],
+    fn_1: collections.abc.Callable[[T0], T1],
+    fn_2: collections.abc.Callable[P, T0],
+) -> collections.abc.Callable[P, T2]: ...
 @typing.overload
 def compose[**P, T0, T1, T2, T3](
-    fn_0: typing.Callable[[T2], T3],
-    fn_1: typing.Callable[[T1], T2],
-    fn_2: typing.Callable[[T0], T1],
-    fn_3: typing.Callable[P, T0],
-) -> typing.Callable[P, T3]: ...
+    fn_0: collections.abc.Callable[[T2], T3],
+    fn_1: collections.abc.Callable[[T1], T2],
+    fn_2: collections.abc.Callable[[T0], T1],
+    fn_3: collections.abc.Callable[P, T0],
+) -> collections.abc.Callable[P, T3]: ...
 @typing.overload
 def compose[**P, T0, T1, T2, T3, T4](
-    fn_0: typing.Callable[[T3], T4],
-    fn_1: typing.Callable[[T2], T3],
-    fn_2: typing.Callable[[T1], T2],
-    fn_3: typing.Callable[[T0], T1],
-    fn_4: typing.Callable[P, T0],
-) -> typing.Callable[P, T4]: ...
+    fn_0: collections.abc.Callable[[T3], T4],
+    fn_1: collections.abc.Callable[[T2], T3],
+    fn_2: collections.abc.Callable[[T1], T2],
+    fn_3: collections.abc.Callable[[T0], T1],
+    fn_4: collections.abc.Callable[P, T0],
+) -> collections.abc.Callable[P, T4]: ...
 @typing.overload
 def compose[**P, T0, T1, T2, T3, T4, T5](
-    fn_0: typing.Callable[[T4], T5],
-    fn_1: typing.Callable[[T3], T4],
-    fn_2: typing.Callable[[T2], T3],
-    fn_3: typing.Callable[[T1], T2],
-    fn_4: typing.Callable[[T0], T1],
-    fn_5: typing.Callable[P, T0],
-) -> typing.Callable[P, T5]: ...
+    fn_0: collections.abc.Callable[[T4], T5],
+    fn_1: collections.abc.Callable[[T3], T4],
+    fn_2: collections.abc.Callable[[T2], T3],
+    fn_3: collections.abc.Callable[[T1], T2],
+    fn_4: collections.abc.Callable[[T0], T1],
+    fn_5: collections.abc.Callable[P, T0],
+) -> collections.abc.Callable[P, T5]: ...
 @typing.overload
 def compose(
-    *funcs: typing.Callable[..., typing.Any],
-) -> typing.Callable[..., typing.Any]: ...
+    *funcs: collections.abc.Callable[..., typing.Any],
+) -> collections.abc.Callable[..., typing.Any]: ...
 def compose(
-    *funcs: typing.Callable[..., typing.Any],
-) -> typing.Callable[..., typing.Any]:
+    *funcs: collections.abc.Callable[..., typing.Any],
+) -> collections.abc.Callable[..., typing.Any]:
     """Compose functions to operate in series.
 
     Returns a function that applies other functions in sequence.
@@ -375,48 +386,50 @@ def compose(
     ...
 
 @typing.overload
-def compose_left[**P, T](fn_0: typing.Callable[P, T]) -> typing.Callable[P, T]: ...
+def compose_left[**P, T](
+    fn_0: collections.abc.Callable[P, T],
+) -> collections.abc.Callable[P, T]: ...
 @typing.overload
 def compose_left[**P, T0, T1](
-    fn_0: typing.Callable[P, T0], fn_1: typing.Callable[[T0], T1]
-) -> typing.Callable[P, T1]: ...
+    fn_0: collections.abc.Callable[P, T0], fn_1: collections.abc.Callable[[T0], T1]
+) -> collections.abc.Callable[P, T1]: ...
 @typing.overload
 def compose_left[**P, T0, T1, T2](
-    fn_0: typing.Callable[P, T0],
-    fn_1: typing.Callable[[T0], T1],
-    fn_2: typing.Callable[[T1], T2],
-) -> typing.Callable[P, T2]: ...
+    fn_0: collections.abc.Callable[P, T0],
+    fn_1: collections.abc.Callable[[T0], T1],
+    fn_2: collections.abc.Callable[[T1], T2],
+) -> collections.abc.Callable[P, T2]: ...
 @typing.overload
 def compose_left[**P, T0, T1, T2, T3](
-    fn_0: typing.Callable[P, T0],
-    fn_1: typing.Callable[[T0], T1],
-    fn_2: typing.Callable[[T1], T2],
-    fn_3: typing.Callable[[T2], T3],
-) -> typing.Callable[P, T3]: ...
+    fn_0: collections.abc.Callable[P, T0],
+    fn_1: collections.abc.Callable[[T0], T1],
+    fn_2: collections.abc.Callable[[T1], T2],
+    fn_3: collections.abc.Callable[[T2], T3],
+) -> collections.abc.Callable[P, T3]: ...
 @typing.overload
 def compose_left[**P, T0, T1, T2, T3, T4](
-    fn_0: typing.Callable[P, T0],
-    fn_1: typing.Callable[[T0], T1],
-    fn_2: typing.Callable[[T1], T2],
-    fn_3: typing.Callable[[T2], T3],
-    fn_4: typing.Callable[[T3], T4],
-) -> typing.Callable[P, T4]: ...
+    fn_0: collections.abc.Callable[P, T0],
+    fn_1: collections.abc.Callable[[T0], T1],
+    fn_2: collections.abc.Callable[[T1], T2],
+    fn_3: collections.abc.Callable[[T2], T3],
+    fn_4: collections.abc.Callable[[T3], T4],
+) -> collections.abc.Callable[P, T4]: ...
 @typing.overload
 def compose_left[**P, T0, T1, T2, T3, T4, T5](
-    fn_0: typing.Callable[P, T0],
-    fn_1: typing.Callable[[T0], T1],
-    fn_2: typing.Callable[[T1], T2],
-    fn_3: typing.Callable[[T2], T3],
-    fn_4: typing.Callable[[T3], T4],
-    fn_5: typing.Callable[[T4], T5],
-) -> typing.Callable[P, T5]: ...
+    fn_0: collections.abc.Callable[P, T0],
+    fn_1: collections.abc.Callable[[T0], T1],
+    fn_2: collections.abc.Callable[[T1], T2],
+    fn_3: collections.abc.Callable[[T2], T3],
+    fn_4: collections.abc.Callable[[T3], T4],
+    fn_5: collections.abc.Callable[[T4], T5],
+) -> collections.abc.Callable[P, T5]: ...
 @typing.overload
 def compose_left(
-    *funcs: typing.Callable[..., typing.Any],
-) -> typing.Callable[..., typing.Any]: ...
+    *funcs: collections.abc.Callable[..., typing.Any],
+) -> collections.abc.Callable[..., typing.Any]: ...
 def compose_left(
-    *funcs: typing.Callable[..., typing.Any],
-) -> typing.Callable[..., typing.Any]:
+    *funcs: collections.abc.Callable[..., typing.Any],
+) -> collections.abc.Callable[..., typing.Any]:
     """Compose functions to operate in series.
 
     Returns a function that applies other functions in sequence.
@@ -439,51 +452,55 @@ def compose_left(
 @typing.overload
 def pipe[T0, T1](
     data: T0,
-    fn_0: typing.Callable[[T0], T1],
+    fn_0: collections.abc.Callable[[T0], T1],
 ) -> T1: ...
 @typing.overload
 def pipe[T0, T1, T2](
     data: T0,
-    fn_0: typing.Callable[[T0], T1],
-    fn_1: typing.Callable[[T1], T2],
+    fn_0: collections.abc.Callable[[T0], T1],
+    fn_1: collections.abc.Callable[[T1], T2],
 ) -> T2: ...
 @typing.overload
 def pipe[T0, T1, T2, T3](
     data: T0,
-    fn_0: typing.Callable[[T0], T1],
-    fn_1: typing.Callable[[T1], T2],
-    fn_2: typing.Callable[[T2], T3],
+    fn_0: collections.abc.Callable[[T0], T1],
+    fn_1: collections.abc.Callable[[T1], T2],
+    fn_2: collections.abc.Callable[[T2], T3],
 ) -> T3: ...
 @typing.overload
 def pipe[T0, T1, T2, T3, T4](
     data: T0,
-    fn_0: typing.Callable[[T0], T1],
-    fn_1: typing.Callable[[T1], T2],
-    fn_2: typing.Callable[[T2], T3],
-    fn_3: typing.Callable[[T3], T4],
+    fn_0: collections.abc.Callable[[T0], T1],
+    fn_1: collections.abc.Callable[[T1], T2],
+    fn_2: collections.abc.Callable[[T2], T3],
+    fn_3: collections.abc.Callable[[T3], T4],
 ) -> T4: ...
 @typing.overload
 def pipe[T0, T1, T2, T3, T4, T5](
     data: T0,
-    fn_0: typing.Callable[[T0], T1],
-    fn_1: typing.Callable[[T1], T2],
-    fn_2: typing.Callable[[T2], T3],
-    fn_3: typing.Callable[[T3], T4],
-    fn_4: typing.Callable[[T4], T5],
+    fn_0: collections.abc.Callable[[T0], T1],
+    fn_1: collections.abc.Callable[[T1], T2],
+    fn_2: collections.abc.Callable[[T2], T3],
+    fn_3: collections.abc.Callable[[T3], T4],
+    fn_4: collections.abc.Callable[[T4], T5],
 ) -> T5: ...
 @typing.overload
 def pipe[T0, T1, T2, T3, T4, T5, T6](
     data: T0,
-    fn_0: typing.Callable[[T0], T1],
-    fn_1: typing.Callable[[T1], T2],
-    fn_2: typing.Callable[[T2], T3],
-    fn_3: typing.Callable[[T3], T4],
-    fn_4: typing.Callable[[T4], T5],
-    fn_5: typing.Callable[[T5], T6],
+    fn_0: collections.abc.Callable[[T0], T1],
+    fn_1: collections.abc.Callable[[T1], T2],
+    fn_2: collections.abc.Callable[[T2], T3],
+    fn_3: collections.abc.Callable[[T3], T4],
+    fn_4: collections.abc.Callable[[T4], T5],
+    fn_5: collections.abc.Callable[[T5], T6],
 ) -> T6: ...
 @typing.overload
-def pipe(data: typing.Any, *funcs: typing.Callable[..., typing.Any]) -> typing.Any: ...
-def pipe(data: typing.Any, *funcs: typing.Callable[..., typing.Any]) -> typing.Any:
+def pipe(
+    data: typing.Any, *funcs: collections.abc.Callable[..., typing.Any]
+) -> typing.Any: ...
+def pipe(
+    data: typing.Any, *funcs: collections.abc.Callable[..., typing.Any]
+) -> typing.Any:
     """Pipe a value through a sequence of functions
 
     I.e. ``pipe(data, f, g, h)`` is equivalent to ``h(g(f(data)))``
@@ -505,7 +522,9 @@ def pipe(data: typing.Any, *funcs: typing.Callable[..., typing.Any]) -> typing.A
     """
     ...
 
-def complement[**P](func: typing.Callable[P, bool]) -> typing.Callable[P, bool]:
+def complement[**P](
+    func: collections.abc.Callable[P, bool],
+) -> collections.abc.Callable[P, bool]:
     """Convert a predicate function to its logical complement.
 
     In other words, return a function that, for inputs that normally
@@ -521,57 +540,58 @@ def complement[**P](func: typing.Callable[P, bool]) -> typing.Callable[P, bool]:
     ...
 
 @typing.overload
-def juxt() -> typing.Callable[..., tuple[()]]: ...
+def juxt() -> collections.abc.Callable[..., tuple[()]]: ...
 @typing.overload
 def juxt[**P, T0](
-    fn_0: typing.Callable[P, T0],
-) -> typing.Callable[P, tuple[T0]]: ...
+    fn_0: collections.abc.Callable[P, T0],
+) -> collections.abc.Callable[P, tuple[T0]]: ...
 @typing.overload
 def juxt[**P, T0, T1](
-    fn_0: typing.Callable[P, T0],
-    fn_1: typing.Callable[P, T1],
-) -> typing.Callable[P, tuple[T0, T1]]: ...
+    fn_0: collections.abc.Callable[P, T0],
+    fn_1: collections.abc.Callable[P, T1],
+) -> collections.abc.Callable[P, tuple[T0, T1]]: ...
 @typing.overload
 def juxt[**P, T0, T1, T2](
-    fn_0: typing.Callable[P, T0],
-    fn_1: typing.Callable[P, T1],
-    fn_2: typing.Callable[P, T2],
-) -> typing.Callable[P, tuple[T0, T1, T2]]: ...
+    fn_0: collections.abc.Callable[P, T0],
+    fn_1: collections.abc.Callable[P, T1],
+    fn_2: collections.abc.Callable[P, T2],
+) -> collections.abc.Callable[P, tuple[T0, T1, T2]]: ...
 @typing.overload
 def juxt[**P, T0, T1, T2, T3](
-    fn_0: typing.Callable[P, T0],
-    fn_1: typing.Callable[P, T1],
-    fn_2: typing.Callable[P, T2],
-    fn_3: typing.Callable[P, T3],
-) -> typing.Callable[P, tuple[T0, T1, T2, T3]]: ...
+    fn_0: collections.abc.Callable[P, T0],
+    fn_1: collections.abc.Callable[P, T1],
+    fn_2: collections.abc.Callable[P, T2],
+    fn_3: collections.abc.Callable[P, T3],
+) -> collections.abc.Callable[P, tuple[T0, T1, T2, T3]]: ...
 @typing.overload
 def juxt[**P, T0, T1, T2, T3, T4](
-    fn_0: typing.Callable[P, T0],
-    fn_1: typing.Callable[P, T1],
-    fn_2: typing.Callable[P, T2],
-    fn_3: typing.Callable[P, T3],
-    fn_4: typing.Callable[P, T4],
-) -> typing.Callable[P, tuple[T0, T1, T2, T3, T4]]: ...
+    fn_0: collections.abc.Callable[P, T0],
+    fn_1: collections.abc.Callable[P, T1],
+    fn_2: collections.abc.Callable[P, T2],
+    fn_3: collections.abc.Callable[P, T3],
+    fn_4: collections.abc.Callable[P, T4],
+) -> collections.abc.Callable[P, tuple[T0, T1, T2, T3, T4]]: ...
 @typing.overload
 def juxt[**P, T0, T1, T2, T3, T4, T5](
-    fn_0: typing.Callable[P, T0],
-    fn_1: typing.Callable[P, T1],
-    fn_2: typing.Callable[P, T2],
-    fn_3: typing.Callable[P, T3],
-    fn_4: typing.Callable[P, T4],
-    fn_5: typing.Callable[P, T5],
-) -> typing.Callable[P, tuple[T0, T1, T2, T3, T4, T5]]: ...
+    fn_0: collections.abc.Callable[P, T0],
+    fn_1: collections.abc.Callable[P, T1],
+    fn_2: collections.abc.Callable[P, T2],
+    fn_3: collections.abc.Callable[P, T3],
+    fn_4: collections.abc.Callable[P, T4],
+    fn_5: collections.abc.Callable[P, T5],
+) -> collections.abc.Callable[P, tuple[T0, T1, T2, T3, T4, T5]]: ...
 @typing.overload
 def juxt[**P, T](
-    funcs: collections.abc.Iterable[typing.Callable[P, T]],
-) -> typing.Callable[P, tuple[T, ...]]: ...
+    funcs: collections.abc.Iterable[collections.abc.Callable[P, T]],
+) -> collections.abc.Callable[P, tuple[T, ...]]: ...
 @typing.overload
 def juxt[**P, T](
-    *funcs: typing.Callable[P, T],
-) -> typing.Callable[P, tuple[T, ...]]: ...
+    *funcs: collections.abc.Callable[P, T],
+) -> collections.abc.Callable[P, tuple[T, ...]]: ...
 def juxt[**P, T](
-    *funcs: typing.Callable[P, T] | collections.abc.Iterable[typing.Callable[P, T]],
-) -> typing.Callable[P, tuple[T, ...]]:
+    *funcs: collections.abc.Callable[P, T]
+    | collections.abc.Iterable[collections.abc.Callable[P, T]],
+) -> collections.abc.Callable[P, tuple[T, ...]]:
     """Creates a function that calls several functions with the same arguments
 
     Takes several functions and returns a function that applies its arguments
@@ -589,7 +609,7 @@ def juxt[**P, T](
     """
     ...
 
-def do[T](func: typing.Callable[[T], typing.Any], x: T) -> T:
+def do[T](func: collections.abc.Callable[[T], typing.Any], x: T) -> T:
     """Runs ``func`` on ``x``, returns ``x``
 
     Because the results of ``func`` are not returned, only the side
@@ -614,7 +634,7 @@ def do[T](func: typing.Callable[[T], typing.Any], x: T) -> T:
     ...
 
 @curry
-def flip[T, U, R](func: typing.Callable[[T, U], R], a: U, b: T) -> R:
+def flip[T, U, R](func: collections.abc.Callable[[T, U], R], a: U, b: T) -> R:
     """Call the function call with the arguments flipped
 
     This function is curried.
@@ -671,8 +691,8 @@ class excepts[T, **P]:
     def __init__(
         self,
         exc: type[Exception] | tuple[type[Exception], ...],
-        func: typing.Callable[P, T],
-        handler: typing.Callable[[Exception], T] | None = None,
+        func: collections.abc.Callable[P, T],
+        handler: collections.abc.Callable[[Exception], T] | None = None,
     ) -> None: ...
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T: ...
     @property

--- a/src/toolz-stubs/itertoolz.pyi
+++ b/src/toolz-stubs/itertoolz.pyi
@@ -55,7 +55,7 @@ class _Randomable(typing.Protocol):
 ### Toolz itself
 
 def remove[T](
-    predicate: typing.Callable[[T], bool], seq: collections.abc.Iterable[T]
+    predicate: collections.abc.Callable[[T], bool], seq: collections.abc.Iterable[T]
 ) -> collections.abc.Iterable[T]:
     """Return those items of sequence for which predicate(item) is False
 
@@ -68,15 +68,17 @@ def remove[T](
 
 @typing.overload
 def accumulate[T](
-    binop: typing.Callable[[T, T], T],
+    binop: collections.abc.Callable[[T, T], T],
     seq: collections.abc.Iterable[T],
 ) -> collections.abc.Iterator[T]: ...
 @typing.overload
 def accumulate[T](
-    binop: typing.Callable[[T, T], T], seq: collections.abc.Iterable[T], initial: T
+    binop: collections.abc.Callable[[T, T], T],
+    seq: collections.abc.Iterable[T],
+    initial: T,
 ) -> collections.abc.Iterator[T]: ...
 def accumulate[T](
-    binop: typing.Callable[[T, T], T],
+    binop: collections.abc.Callable[[T, T], T],
     seq: collections.abc.Iterable[T],
     initial: T | _NoDefaultType = no_default,
 ) -> collections.abc.Iterator[T]:
@@ -109,7 +111,7 @@ def accumulate[T](
     ...
 
 def groupby[KT, T](
-    key: typing.Callable[[T], KT], seq: collections.abc.Iterable[T]
+    key: collections.abc.Callable[[T], KT], seq: collections.abc.Iterable[T]
 ) -> dict[KT, list[T]]:
     """Group a collection by a key function
 
@@ -138,7 +140,8 @@ def groupby[KT, T](
     ...
 
 def merge_sorted[CT: SupportsRichComparison](
-    *seqs: collections.abc.Iterable[CT], key: typing.Callable[[CT], CT] | None = None
+    *seqs: collections.abc.Iterable[CT],
+    key: collections.abc.Callable[[CT], CT] | None = None,
 ) -> collections.abc.Iterator[CT]:
     """Merge and sort a collection of sorted collections
 
@@ -176,7 +179,7 @@ def interleave[T](
 
 def unique[T](
     seq: collections.abc.Iterable[T],
-    key: typing.Callable[[T], typing.Any] | None = None,
+    key: collections.abc.Callable[[T], typing.Any] | None = None,
 ) -> collections.abc.Iterator[T]:
     """Return only unique elements of a sequence
 
@@ -390,7 +393,7 @@ def concatv[T](*seqs: collections.abc.Iterable[T]) -> collections.abc.Iterator[T
     ...
 
 def mapcat[T, R](
-    func: typing.Callable[[T], collections.abc.Iterable[R]],
+    func: collections.abc.Callable[[T], collections.abc.Iterable[R]],
     seqs: collections.abc.Iterable[T],
 ) -> collections.abc.Iterator[R]:
     """Apply func to each sequence in seqs, concatenating results.
@@ -433,35 +436,35 @@ def frequencies[T](seq: collections.abc.Iterable[T]) -> dict[T, int]:
 
 @typing.overload
 def reduceby[T, K](
-    key: typing.Callable[[T], K],
-    binop: typing.Callable[[T, T], T],
+    key: collections.abc.Callable[[T], K],
+    binop: collections.abc.Callable[[T, T], T],
     seq: collections.abc.Iterable[T],
 ) -> dict[K, T]: ...
 @typing.overload
 def reduceby[T, K](
-    key: typing.Callable[[T], K],
-    binop: typing.Callable[[T, T], T],
+    key: collections.abc.Callable[[T], K],
+    binop: collections.abc.Callable[[T, T], T],
     seq: collections.abc.Iterable[T],
-    init: T | typing.Callable[[], T],
+    init: T | collections.abc.Callable[[], T],
 ) -> dict[K, T]: ...
 @typing.overload
 def reduceby[T](
     key: typing.Any,  # when not callable, use identity function
-    binop: typing.Callable[[T, T], T],
+    binop: collections.abc.Callable[[T, T], T],
     seq: collections.abc.Iterable[T],
 ) -> dict[T, T]: ...
 @typing.overload
 def reduceby[T](
     key: typing.Any,  # when not callable, use identity function
-    binop: typing.Callable[[T, T], T],
+    binop: collections.abc.Callable[[T, T], T],
     seq: collections.abc.Iterable[T],
-    init: T | typing.Callable[[], T],
+    init: T | collections.abc.Callable[[], T],
 ) -> dict[T, T]: ...
 def reduceby[T, K](
-    key: typing.Callable[[T], K] | typing.Any,
-    binop: typing.Callable[[T, T], T],
+    key: collections.abc.Callable[[T], K] | typing.Any,
+    binop: collections.abc.Callable[[T, T], T],
     seq: collections.abc.Iterable[T],
-    init: T | typing.Callable[[], T] | _NoDefaultType = no_default,
+    init: T | collections.abc.Callable[[], T] | _NoDefaultType = no_default,
 ) -> dict[K, T]:
     """Perform a simultaneous groupby and reduction
 
@@ -525,7 +528,9 @@ def reduceby[T, K](
     """
     ...
 
-def iterate[T](func: typing.Callable[[T], T], x: T) -> collections.abc.Iterator[T]:
+def iterate[T](
+    func: collections.abc.Callable[[T], T], x: T
+) -> collections.abc.Iterator[T]:
     """Repeatedly apply a function func onto an original input
 
     Yields x, then func(x), then func(func(x)), then func(func(func(x))), etc..
@@ -693,19 +698,19 @@ def pluck[T](
 @typing.overload
 def getter[T](
     index: list[typing.Any],
-) -> typing.Callable[
+) -> collections.abc.Callable[
     [collections.abc.Sequence[T] | collections.abc.Mapping[typing.Any, T]],
     tuple[T, ...],
 ]: ...
 @typing.overload
 def getter[T](
     index: typing.Any,
-) -> typing.Callable[
+) -> collections.abc.Callable[
     [collections.abc.Sequence[T] | collections.abc.Mapping[typing.Any, T]], T
 ]: ...
 def getter[T](
     index: typing.Any | list[typing.Any],
-) -> typing.Callable[
+) -> collections.abc.Callable[
     [collections.abc.Sequence[T] | collections.abc.Mapping[typing.Any, T]],
     T | tuple[T, ...],
 ]:
@@ -715,33 +720,33 @@ def getter[T](
 # === CALLABLE + CALLABLE (4 overloads) ===
 @typing.overload
 def join[T, U](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable],
+    rightkey: collections.abc.Callable[[U], typing.Hashable],
     rightseq: collections.abc.Iterable[U],
 ) -> collections.abc.Iterator[tuple[T, U]]: ...
 @typing.overload
 def join[T, U, L](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable],
+    rightkey: collections.abc.Callable[[U], typing.Hashable],
     rightseq: collections.abc.Iterable[U],
     left_default: L,
 ) -> collections.abc.Iterator[tuple[T | L, U]]: ...
 @typing.overload
 def join[T, U, R](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable],
+    rightkey: collections.abc.Callable[[U], typing.Hashable],
     rightseq: collections.abc.Iterable[U],
     *,
     right_default: R,
 ) -> collections.abc.Iterator[tuple[T, U | R]]: ...
 @typing.overload
 def join[T, U, L, R](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable],
+    rightkey: collections.abc.Callable[[U], typing.Hashable],
     rightseq: collections.abc.Iterable[U],
     left_default: L,
     right_default: R,
@@ -752,14 +757,14 @@ def join[T, U, L, R](
 def join[T, U](
     leftkey: typing.Hashable,
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable],
+    rightkey: collections.abc.Callable[[U], typing.Hashable],
     rightseq: collections.abc.Iterable[U],
 ) -> collections.abc.Iterator[tuple[T, U]]: ...
 @typing.overload
 def join[T, U, L](
     leftkey: typing.Hashable,
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable],
+    rightkey: collections.abc.Callable[[U], typing.Hashable],
     rightseq: collections.abc.Iterable[U],
     left_default: L,
 ) -> collections.abc.Iterator[tuple[T | L, U]]: ...
@@ -767,7 +772,7 @@ def join[T, U, L](
 def join[T, U, R](
     leftkey: typing.Hashable,
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable],
+    rightkey: collections.abc.Callable[[U], typing.Hashable],
     rightseq: collections.abc.Iterable[U],
     *,
     right_default: R,
@@ -776,7 +781,7 @@ def join[T, U, R](
 def join[T, U, L, R](
     leftkey: typing.Hashable,
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable],
+    rightkey: collections.abc.Callable[[U], typing.Hashable],
     rightseq: collections.abc.Iterable[U],
     left_default: L,
     right_default: R,
@@ -785,14 +790,14 @@ def join[T, U, L, R](
 # === CALLABLE + HASHABLE (4 overloads) ===
 @typing.overload
 def join[T, U](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
     rightkey: typing.Hashable,
     rightseq: collections.abc.Iterable[U],
 ) -> collections.abc.Iterator[tuple[T, U]]: ...
 @typing.overload
 def join[T, U, L](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
     rightkey: typing.Hashable,
     rightseq: collections.abc.Iterable[U],
@@ -800,7 +805,7 @@ def join[T, U, L](
 ) -> collections.abc.Iterator[tuple[T | L, U]]: ...
 @typing.overload
 def join[T, U, R](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
     rightkey: typing.Hashable,
     rightseq: collections.abc.Iterable[U],
@@ -809,7 +814,7 @@ def join[T, U, R](
 ) -> collections.abc.Iterator[tuple[T, U | R]]: ...
 @typing.overload
 def join[T, U, L, R](
-    leftkey: typing.Callable[[T], typing.Hashable],
+    leftkey: collections.abc.Callable[[T], typing.Hashable],
     leftseq: collections.abc.Iterable[T],
     rightkey: typing.Hashable,
     rightseq: collections.abc.Iterable[U],
@@ -854,9 +859,9 @@ def join[T, U, L, R](
 
 # Implementation signature
 def join[T, U, L, R](
-    leftkey: typing.Callable[[T], typing.Hashable] | typing.Hashable,
+    leftkey: collections.abc.Callable[[T], typing.Hashable] | typing.Hashable,
     leftseq: collections.abc.Iterable[T],
-    rightkey: typing.Callable[[U], typing.Hashable] | typing.Hashable,
+    rightkey: collections.abc.Callable[[U], typing.Hashable] | typing.Hashable,
     rightseq: collections.abc.Iterable[U],
     left_default: L | _NoDefaultType = no_default,
     right_default: R | _NoDefaultType = no_default,
@@ -924,18 +929,18 @@ def join[T, U, L, R](
 @typing.overload
 def diff[T](
     *seqs: collections.abc.Iterable[T],
-    key: typing.Callable[[T], typing.Any] | None = None,
+    key: collections.abc.Callable[[T], typing.Any] | None = None,
 ) -> collections.abc.Iterator[tuple[T, ...]]: ...
 @typing.overload
 def diff[T](
     *seqs: collections.abc.Iterable[T],
     default: T,
-    key: typing.Callable[[T], typing.Any] | None = None,
+    key: collections.abc.Callable[[T], typing.Any] | None = None,
 ) -> collections.abc.Iterator[tuple[T, ...]]: ...
 def diff[T](
     *seqs: collections.abc.Iterable[T],
     default: T | _NoDefaultType = no_default,
-    key: typing.Callable[[T], typing.Any] | None = None,
+    key: collections.abc.Callable[[T], typing.Any] | None = None,
 ) -> collections.abc.Iterator[tuple[T, ...]]:
     """Return those items that differ between sequences
 
@@ -958,7 +963,7 @@ def diff[T](
 def topk[T](
     k: int,
     seq: collections.abc.Iterable[T],
-    key: typing.Callable[[T], SupportsRichComparison] | None = None,
+    key: collections.abc.Callable[[T], SupportsRichComparison] | None = None,
 ) -> tuple[T, ...]:
     """Find the k largest elements of a sequence
 

--- a/src/toolz-stubs/recipes.pyi
+++ b/src/toolz-stubs/recipes.pyi
@@ -4,7 +4,7 @@ import typing
 __all__ = ("countby", "partitionby")
 
 def countby[T, K](
-    key: typing.Callable[[T], K], seq: collections.abc.Iterable[T]
+    key: collections.abc.Callable[[T], K], seq: collections.abc.Iterable[T]
 ) -> dict[K, int]:
     """Count elements of a collection by a key function
 
@@ -21,7 +21,7 @@ def countby[T, K](
     ...
 
 def partitionby[T](
-    func: typing.Callable[[T], typing.Any], seq: collections.abc.Iterable[T]
+    func: collections.abc.Callable[[T], typing.Any], seq: collections.abc.Iterable[T]
 ) -> collections.abc.Iterator[tuple[T, ...]]:
     """Partition a sequence according to a function
 

--- a/src/toolz-stubs/sandbox/parallel.pyi
+++ b/src/toolz-stubs/sandbox/parallel.pyi
@@ -10,12 +10,12 @@ type _MapFunction[T] = collections.abc.Callable[
 ]
 
 def fold[T](
-    binop: typing.Callable[[T, T], T],
+    binop: collections.abc.Callable[[T, T], T],
     seq: collections.abc.Iterable[T],
     default: typing.Literal["__no__default__"] | T = "__no_default__",
     map: _MapFunction[T] = map,
     chunksize: int = 128,
-    combine: typing.Callable[[T, T], T] | None = None,
+    combine: collections.abc.Callable[[T, T], T] | None = None,
 ) -> T:
     """
     Reduce without guarantee of ordered reduction.

--- a/src/toolz-stubs/utils.pyi
+++ b/src/toolz-stubs/utils.pyi
@@ -1,5 +1,5 @@
-import typing
+import collections.abc
 
-def raises(err: type[Exception], lamda: typing.Callable[[], None]) -> bool: ...
+def raises(err: type[Exception], lamda: collections.abc.Callable[[], None]) -> bool: ...
 
 no_default = "__no__default__"


### PR DESCRIPTION
Update all instances of `typing.Callable` to `collections.abc.Callable` to comply with Python 3.9 deprecation.