### PR TITLE
Refactor type hints and imports in dicttoolz.pyi

### DIFF
--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -1,6 +1,6 @@
 # pyright: reportExplicitAny = false
 from collections.abc import Callable, Hashable, Mapping, MutableMapping, Sequence
-from typing import Any, Literal, overload, Protocol, TypeGuard
+from typing import overload, TypeGuard, TypeVar, Protocol, Literal
 import sys
 import collections.abc
 import typing
@@ -9,160 +9,140 @@ if sys.version_info >= (3, 13):
     from typing import TypeIs  # pyright: ignore[reportUnreachable]
 else:
     from typing_extensions import TypeIs
+
 __all__ = (
-    "assoc",
-    "assoc_in",
-    "dissoc",
-    "get_in",
-    "itemfilter",
-    "itemmap",
-    "keyfilter",
-    "keymap",
     "merge",
     "merge_with",
-    "update_in",
-    "valfilter",
     "valmap",
+    "keymap",
+    "itemmap",
+    "valfilter",
+    "keyfilter",
+    "itemfilter",
+    "assoc",
+    "dissoc",
+    "assoc_in",
+    "update_in",
+    "get_in",
 )
 
-class SupportsGetItem[K: Hashable, V](Protocol):
-    def __getitem__(self, key: K, /) -> V: ...
+@overload
+def merge[K: Hashable, V](
+    *dicts: Mapping[K, V], factory: Callable[[], dict[K, V]] = dict
+) -> dict[K, V]: ...
+@overload
+def merge[K: Hashable, V](
+    *dicts: Mapping[K, V], factory: Callable[[], MutableMapping[K, V]]
+) -> MutableMapping[K, V]: ...
+def merge[K: Hashable, V](
+    *dicts: Mapping[K, V], factory: Callable[[], MutableMapping[K, V]] = dict
+) -> MutableMapping[K, V]:
+    """Merge a collection of dictionaries
+
+    >>> merge({1: 'one'}, {2: 'two'})
+    {1: 'one', 2: 'two'}
+
+    Later dictionaries have precedence
+
+    >>> merge({1: 2, 3: 4}, {3: 3, 4: 4})
+    {1: 2, 3: 3, 4: 4}
+
+    See Also:
+        merge_with
+    """
+    ...
 
 @overload
-def assoc[K: Hashable, V](
-    d: Mapping[K, V], key: K, value: V, factory: Callable[[], dict[K, V]] = dict
-) -> dict[K, V]: ...
-@overload
-def assoc[K: Hashable, V](
-    d: Mapping[K, V], key: K, value: V, factory: Callable[[], MutableMapping[K, V]]
-) -> MutableMapping[K, V]: ...
-def assoc[K: Hashable, V](
-    d: Mapping[K, V],
-    key: K,
-    value: V,
-    factory: Callable[[], MutableMapping[K, V]] = dict,
-) -> MutableMapping[K, V]: ...
-@overload
-def assoc_in[K1, K2, V1, V2](
-    d: Mapping[K1, Mapping[K2, V2] | V1], keys: tuple[K1, K2], value: V2
-) -> dict[K1, dict[K2, V2] | V1 | V2]: ...
-@overload
-def assoc_in[K1, K2, V1, V2](
-    d: Mapping[K1, Mapping[K2, V2] | V1],
-    keys: tuple[K1, K2],
-    value: V2,
-    *,
-    factory: Callable[[], MutableMapping[K1, Any]],
-) -> MutableMapping[K1, Any]: ...
-@overload
-def assoc_in[K1, K2, K3, V1, V2, V3](
-    d: Mapping[K1, Mapping[K2, Mapping[K3, V3] | V2] | V1],
-    keys: tuple[K1, K2, K3],
-    value: V3,
-) -> dict[K1, dict[K2, dict[K3, V3] | V2 | V3] | V1 | V3]: ...
-@overload
-def assoc_in[K1, K2, K3, V1, V2, V3](
-    d: Mapping[K1, Mapping[K2, Mapping[K3, V3] | V2] | V1],
-    keys: tuple[K1, K2, K3],
-    value: V3,
-    *,
-    factory: Callable[[], MutableMapping[K1, Any]],
-) -> MutableMapping[K1, Any]: ...
-@overload
-def assoc_in[K, V](d: Mapping[K, V], keys: Sequence[K], value: V) -> dict[K, V]: ...
-@overload
-def assoc_in[K, V](
-    d: Mapping[K, V],
-    keys: Sequence[K],
-    value: V,
-    *,
-    factory: Callable[[], MutableMapping[K, V]],
-) -> MutableMapping[K, V]: ...
-def assoc_in[K, V](
-    d: Mapping[K, V],
-    keys: Sequence[K],
-    value: V,
-    *,
-    factory: Callable[[], MutableMapping[K, V]] = dict,
-) -> MutableMapping[K, V]: ...
-@overload
-def dissoc[K: Hashable, V](
-    d: Mapping[K, V], *keys: K, factory: Callable[[], dict[K, V]] = dict
-) -> dict[K, V]: ...
-@overload
-def dissoc[K: Hashable, V](
-    d: Mapping[K, V], *keys: K, factory: Callable[[], MutableMapping[K, V]]
-) -> MutableMapping[K, V]: ...
-def dissoc[K: Hashable, V](
-    d: Mapping[K, V], *keys: K, factory: Callable[[], MutableMapping[K, V]] = dict
-) -> MutableMapping[K, V]: ...
-@overload
-def get_in[K: Hashable, V](
-    keys: Sequence[K],
-    coll: SupportsGetItem[K, V],
-    default: None = None,
-    no_default: Literal[True] = True,
-) -> V: ...
-@overload
-def get_in[K: Hashable, V](
-    keys: Sequence[K],
-    coll: SupportsGetItem[K, V],
-    default: None = None,
-    no_default: bool = False,
-) -> V | None: ...
-@overload
-def get_in[K: Hashable, V](
-    keys: Sequence[K], coll: SupportsGetItem[K, V], default: V, no_default: bool = False
-) -> V: ...
-def get_in[K: Hashable, V](
-    keys: Sequence[K],
-    coll: SupportsGetItem[K, V],
-    default: V | None = None,
-    no_default: bool = False,
-) -> V | None: ...
-@overload
-def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
-    predicate: Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
-    d: Mapping[K0, V0],
-    factory: Callable[[], dict[K1, V1]] = dict,
-) -> dict[K1, V1]: ...
-@overload
-def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
-    predicate: Callable[[tuple[K0, V0]], TypeGuard[tuple[K1, V1]]],
-    d: Mapping[K0, V0],
-    factory: Callable[[], dict[K1, V1]] = dict,
-) -> dict[K1, V1]: ...
-@overload
-def itemfilter[K: Hashable, V](
-    predicate: Callable[[tuple[K, V]], bool],
-    d: Mapping[K, V],
+def merge_with[K: Hashable, V](
+    func: Callable[[Sequence[V]], V],
+    *dicts: Mapping[K, V],
     factory: Callable[[], dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @overload
-def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
-    predicate: Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
-    d: Mapping[K0, V0],
-    factory: Callable[[], MutableMapping[K1, V1]],
-) -> MutableMapping[K1, V1]: ...
+def merge_with[K: Hashable, V](
+    func: Callable[[Sequence[V]], V],
+    *dicts: Mapping[K, V],
+    factory: Callable[[], MutableMapping[K, V]],
+) -> MutableMapping[K, V]: ...
+def merge_with[K: Hashable, V](
+    func: Callable[[Sequence[V]], V],
+    *dicts: Mapping[K, V],
+    factory: Callable[[], MutableMapping[K, V]] = dict,
+) -> MutableMapping[K, V]:
+    """Merge dictionaries and apply function to combined values
+
+    A key may occur in more than one dict, and all values mapped from the key
+    will be passed to the function as a list, such as func([val1, val2, ...]).
+
+    >>> merge_with(sum, {1: 1, 2: 2}, {1: 10, 2: 20})
+    {1: 11, 2: 22}
+
+    >>> merge_with(first, {1: 1, 2: 2}, {2: 20, 3: 30})  # doctest: +SKIP
+    {1: 1, 2: 2, 3: 30}
+
+    See Also:
+        merge
+    """
+    ...
+
 @overload
-def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
-    predicate: Callable[[tuple[K0, V0]], TypeGuard[tuple[K1, V1]]],
-    d: Mapping[K0, V0],
-    factory: Callable[[], MutableMapping[K1, V1]],
-) -> MutableMapping[K1, V1]: ...
+def valmap[K: Hashable, V0, V1](
+    func: Callable[[V0], V1],
+    d: Mapping[K, V0],
+    factory: Callable[[], dict[K, V1]] = dict,
+) -> dict[K, V1]: ...
 @overload
-def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
-    predicate: Callable[[tuple[K0, V0]], bool],
-    d: Mapping[K0, V0],
-    factory: Callable[[], MutableMapping[K1, V1]],
-) -> MutableMapping[K1, V1]: ...
-def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
-    predicate: Callable[[tuple[K0, V0]], bool]
-    | Callable[[tuple[K0, V0]], TypeGuard[tuple[K1, V1]]]
-    | Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
-    d: Mapping[K0, V0],
-    factory: Callable[[], MutableMapping[K1, V1]] = dict,
-) -> MutableMapping[K1, V1]: ...
+def valmap[K: Hashable, V0, V1](
+    func: Callable[[V0], V1],
+    d: Mapping[K, V0],
+    factory: Callable[[], MutableMapping[K, V1]],
+) -> MutableMapping[K, V1]: ...
+def valmap[K: Hashable, V0, V1](
+    func: Callable[[V0], V1],
+    d: Mapping[K, V0],
+    factory: Callable[[], MutableMapping[K, V1]] = dict,
+) -> MutableMapping[K, V1]:
+    """Apply function to values of dictionary
+
+    >>> bills = {"Alice": [20, 15, 30], "Bob": [10, 35]}
+    >>> valmap(sum, bills)  # doctest: +SKIP
+    {'Alice': 65, 'Bob': 45}
+
+    See Also:
+        keymap
+        itemmap
+    """
+    ...
+
+@overload
+def keymap[K0: Hashable, K1: Hashable, V](
+    func: Callable[[K0], K1],
+    d: Mapping[K0, V],
+    factory: Callable[[], dict[K1, V]] = dict,
+) -> dict[K1, V]: ...
+@overload
+def keymap[K0: Hashable, K1: Hashable, V](
+    func: Callable[[K0], K1],
+    d: Mapping[K0, V],
+    factory: Callable[[], MutableMapping[K1, V]],
+) -> MutableMapping[K1, V]: ...
+def keymap[K0: Hashable, K1: Hashable, V](
+    func: Callable[[K0], K1],
+    d: Mapping[K0, V],
+    factory: Callable[[], MutableMapping[K1, V]] = dict,
+) -> MutableMapping[K1, V]:
+    """Apply function to keys of dictionary
+
+    >>> bills = {"Alice": [20, 15, 30], "Bob": [10, 35]}
+    >>> keymap(str.lower, bills)  # doctest: +SKIP
+    {'alice': [20, 15, 30], 'bob': [10, 35]}
+
+    See Also:
+        valmap
+        itemmap
+    """
+    ...
+
 @overload
 def itemmap[K0: Hashable, K1: Hashable, V0, V1](
     func: Callable[[tuple[K0, V0]], tuple[K1, V1]],
@@ -179,7 +159,74 @@ def itemmap[K0: Hashable, K1: Hashable, V0, V1](
     func: Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: Mapping[K0, V0],
     factory: Callable[..., MutableMapping[K1, V1]] = dict,
-) -> MutableMapping[K1, V1]: ...
+) -> MutableMapping[K1, V1]:
+    """Apply function to items of dictionary
+
+    >>> accountids = {"Alice": 10, "Bob": 20}
+    >>> itemmap(reversed, accountids)  # doctest: +SKIP
+    {10: "Alice", 20: "Bob"}
+
+    See Also:
+        keymap
+        valmap
+    """
+    ...
+
+@overload
+def valfilter[K: Hashable, V0, V1](
+    predicate: Callable[[V0], TypeIs[V1]],
+    d: Mapping[K, V0],
+    factory: Callable[[], dict[K, V1]] = dict,
+) -> dict[K, V1]: ...
+@overload
+def valfilter[K: Hashable, V0, V1](
+    predicate: Callable[[V0], TypeGuard[V1]],
+    d: Mapping[K, V0],
+    factory: Callable[[], dict[K, V1]] = dict,
+) -> dict[K, V1]: ...
+@overload
+def valfilter[K: Hashable, V](
+    predicate: Callable[[V], bool], d: Mapping[K, V]
+) -> dict[K, V]: ...
+@overload
+def valfilter[K: Hashable, V0, V1](
+    predicate: Callable[[V0], TypeIs[V1]],
+    d: Mapping[K, V0],
+    factory: Callable[[], MutableMapping[K, V1]],
+) -> MutableMapping[K, V1]: ...
+@overload
+def valfilter[K: Hashable, V0, V1](
+    predicate: Callable[[V0], TypeGuard[V1]],
+    d: Mapping[K, V0],
+    factory: Callable[[], MutableMapping[K, V1]],
+) -> MutableMapping[K, V1]: ...
+@overload
+def valfilter[K: Hashable, V0, V1](
+    predicate: Callable[[V0], bool],
+    d: Mapping[K, V0],
+    factory: Callable[[], MutableMapping[K, V1]],
+) -> MutableMapping[K, V1]: ...
+def valfilter[K: Hashable, V0, V1](
+    predicate: Callable[[V0], bool]
+    | Callable[[V0], TypeGuard[V1]]
+    | Callable[[V0], TypeIs[V1]],
+    d: Mapping[K, V0],
+    factory: Callable[[], MutableMapping[K, V1]] = dict,
+) -> MutableMapping[K, V1]:
+    """Filter items in dictionary by value
+
+    >>> iseven = lambda x: x % 2 == 0
+    >>> d = {1: 2, 2: 3, 3: 4, 4: 5}
+    >>> valfilter(iseven, d)
+    {1: 2, 3: 4}
+
+    See Also:
+        keyfilter
+        itemfilter
+        valmap
+    """
+    ...
+
 @overload
 def keyfilter[K0: Hashable, K1: Hashable, V](
     predicate: Callable[[K0], TypeIs[K1]],
@@ -222,52 +269,206 @@ def keyfilter[K0: Hashable, K1: Hashable, V](
     | Callable[[K0], TypeIs[K1]],
     d: Mapping[K0, V],
     factory: Callable[[], MutableMapping[K1, V]] = dict,
-) -> MutableMapping[K1, V]: ...
+) -> MutableMapping[K1, V]:
+    """Filter items in dictionary by key
+
+    >>> iseven = lambda x: x % 2 == 0
+    >>> d = {1: 2, 2: 3, 3: 4, 4: 5}
+    >>> keyfilter(iseven, d)
+    {2: 3, 4: 5}
+
+    See Also:
+        valfilter
+        itemfilter
+        keymap
+    """
+    ...
+
 @overload
-def keymap[K0: Hashable, K1: Hashable, V](
-    func: Callable[[K0], K1],
-    d: Mapping[K0, V],
-    factory: Callable[[], dict[K1, V]] = dict,
-) -> dict[K1, V]: ...
+def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
+    predicate: Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
+    d: Mapping[K0, V0],
+    factory: Callable[[], dict[K1, V1]] = dict,
+) -> dict[K1, V1]: ...
 @overload
-def keymap[K0: Hashable, K1: Hashable, V](
-    func: Callable[[K0], K1],
-    d: Mapping[K0, V],
-    factory: Callable[[], MutableMapping[K1, V]],
-) -> MutableMapping[K1, V]: ...
-def keymap[K0: Hashable, K1: Hashable, V](
-    func: Callable[[K0], K1],
-    d: Mapping[K0, V],
-    factory: Callable[[], MutableMapping[K1, V]] = dict,
-) -> MutableMapping[K1, V]: ...
+def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
+    predicate: Callable[[tuple[K0, V0]], TypeGuard[tuple[K1, V1]]],
+    d: Mapping[K0, V0],
+    factory: Callable[[], dict[K1, V1]] = dict,
+) -> dict[K1, V1]: ...
 @overload
-def merge[K: Hashable, V](
-    *dicts: Mapping[K, V], factory: Callable[[], dict[K, V]] = dict
-) -> dict[K, V]: ...
-@overload
-def merge[K: Hashable, V](
-    *dicts: Mapping[K, V], factory: Callable[[], MutableMapping[K, V]]
-) -> MutableMapping[K, V]: ...
-def merge[K: Hashable, V](
-    *dicts: Mapping[K, V], factory: Callable[[], MutableMapping[K, V]] = dict
-) -> MutableMapping[K, V]: ...
-@overload
-def merge_with[K: Hashable, V](
-    func: Callable[[Sequence[V]], V],
-    *dicts: Mapping[K, V],
+def itemfilter[K: Hashable, V](
+    predicate: Callable[[tuple[K, V]], bool],
+    d: Mapping[K, V],
     factory: Callable[[], dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @overload
-def merge_with[K: Hashable, V](
-    func: Callable[[Sequence[V]], V],
-    *dicts: Mapping[K, V],
-    factory: Callable[[], MutableMapping[K, V]],
+def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
+    predicate: Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
+    d: Mapping[K0, V0],
+    factory: Callable[[], MutableMapping[K1, V1]],
+) -> MutableMapping[K1, V1]: ...
+@overload
+def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
+    predicate: Callable[[tuple[K0, V0]], TypeGuard[tuple[K1, V1]]],
+    d: Mapping[K0, V0],
+    factory: Callable[[], MutableMapping[K1, V1]],
+) -> MutableMapping[K1, V1]: ...
+@overload
+def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
+    predicate: Callable[[tuple[K0, V0]], bool],
+    d: Mapping[K0, V0],
+    factory: Callable[[], MutableMapping[K1, V1]],
+) -> MutableMapping[K1, V1]: ...
+def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
+    predicate: Callable[[tuple[K0, V0]], bool]
+    | Callable[[tuple[K0, V0]], TypeGuard[tuple[K1, V1]]]
+    | Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
+    d: Mapping[K0, V0],
+    factory: Callable[[], MutableMapping[K1, V1]] = dict,
+) -> MutableMapping[K1, V1]:
+    """Filter items in dictionary by item
+
+    >>> def isvalid(item):
+    ...     k, v = item
+    ...     return k % 2 == 0 and v < 4
+
+    >>> d = {1: 2, 2: 3, 3: 4, 4: 5}
+    >>> itemfilter(isvalid, d)
+    {2: 3}
+
+    See Also:
+        keyfilter
+        valfilter
+        itemmap
+    """
+    ...
+
+@overload
+def assoc[K: Hashable, V](
+    d: Mapping[K, V], key: K, value: V, factory: Callable[[], dict[K, V]] = dict
+) -> dict[K, V]: ...
+@overload
+def assoc[K: Hashable, V](
+    d: Mapping[K, V], key: K, value: V, factory: Callable[[], MutableMapping[K, V]]
 ) -> MutableMapping[K, V]: ...
-def merge_with[K: Hashable, V](
-    func: Callable[[Sequence[V]], V],
-    *dicts: Mapping[K, V],
+def assoc[K: Hashable, V](
+    d: Mapping[K, V],
+    key: K,
+    value: V,
     factory: Callable[[], MutableMapping[K, V]] = dict,
+) -> MutableMapping[K, V]:
+    """Return a new dict with new key value pair
+
+    New dict has d[key] set to value. Does not modify the initial dictionary.
+
+    >>> assoc({'x': 1}, 'x', 2)
+    {'x': 2}
+    >>> assoc({'x': 1}, 'y', 3)   # doctest: +SKIP
+    {'x': 1, 'y': 3}
+    """
+    ...
+
+@overload
+def dissoc[K: Hashable, V](
+    d: Mapping[K, V], *keys: K, factory: Callable[[], dict[K, V]] = dict
+) -> dict[K, V]: ...
+@overload
+def dissoc[K: Hashable, V](
+    d: Mapping[K, V], *keys: K, factory: Callable[[], MutableMapping[K, V]]
 ) -> MutableMapping[K, V]: ...
+def dissoc[K: Hashable, V](
+    d: Mapping[K, V], *keys: K, factory: Callable[[], MutableMapping[K, V]] = dict
+) -> MutableMapping[K, V]:
+    """Return a new dict with the given key(s) removed.
+
+    New dict has d[key] deleted for each supplied key.
+    Does not modify the initial dictionary.
+
+    >>> dissoc({'x': 1, 'y': 2}, 'y')
+    {'x': 1}
+    >>> dissoc({'x': 1, 'y': 2}, 'y', 'x')
+    {}
+    >>> dissoc({'x': 1}, 'y') # Ignores missing keys
+    {'x': 1}
+    """
+    ...
+
+# Overloads for nested dictionaries with tuple keys (2-level nesting)
+@typing.overload
+def assoc_in[K1, K2, V1, V2](
+    d: collections.abc.Mapping[K1, collections.abc.Mapping[K2, V2] | V1],
+    keys: tuple[K1, K2],
+    value: V2,
+) -> dict[K1, dict[K2, V2] | V1 | V2]: ...
+@typing.overload
+def assoc_in[K1, K2, V1, V2](
+    d: collections.abc.Mapping[K1, collections.abc.Mapping[K2, V2] | V1],
+    keys: tuple[K1, K2],
+    value: V2,
+    *,
+    factory: collections.abc.Callable[
+        [], collections.abc.MutableMapping[K1, typing.Any]
+    ],
+) -> collections.abc.MutableMapping[K1, typing.Any]: ...
+
+# Overloads for nested dictionaries with tuple keys (3-level nesting)
+@typing.overload
+def assoc_in[K1, K2, K3, V1, V2, V3](
+    d: collections.abc.Mapping[
+        K1, collections.abc.Mapping[K2, collections.abc.Mapping[K3, V3] | V2] | V1
+    ],
+    keys: tuple[K1, K2, K3],
+    value: V3,
+) -> dict[K1, dict[K2, dict[K3, V3] | V2 | V3] | V1 | V3]: ...
+@typing.overload
+def assoc_in[K1, K2, K3, V1, V2, V3](
+    d: collections.abc.Mapping[
+        K1, collections.abc.Mapping[K2, collections.abc.Mapping[K3, V3] | V2] | V1
+    ],
+    keys: tuple[K1, K2, K3],
+    value: V3,
+    *,
+    factory: collections.abc.Callable[
+        [], collections.abc.MutableMapping[K1, typing.Any]
+    ],
+) -> collections.abc.MutableMapping[K1, typing.Any]: ...
+
+# General overloads for backwards compatibility
+@typing.overload
+def assoc_in[K, V](
+    d: collections.abc.Mapping[K, V],
+    keys: collections.abc.Iterable[K] | K,
+    value: V,
+) -> dict[K, V]: ...
+@typing.overload
+def assoc_in[K, V](
+    d: collections.abc.Mapping[K, V],
+    keys: collections.abc.Iterable[K] | K,
+    value: V,
+    *,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+) -> collections.abc.MutableMapping[K, V]: ...
+def assoc_in[K, V](
+    d: collections.abc.Mapping[K, V],
+    keys: collections.abc.Iterable[K] | K,
+    value: V,
+    *,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+) -> collections.abc.MutableMapping[K, V]:
+    """Return a new dict with new, potentially nested, key value pair
+
+    >>> purchase = {'name': 'Alice',
+    ...             'order': {'items': ['Apple', 'Orange'],
+    ...                       'costs': [0.50, 1.25]},
+    ...             'credit card': '5555-1234-1234-1234'}
+    >>> assoc_in(purchase, ['order', 'costs'], [0.25, 1.00]) # doctest: +SKIP
+    {'credit card': '5555-1234-1234-1234',
+     'name': 'Alice',
+     'order': {'costs': [0.25, 1.00], 'items': ['Apple', 'Orange']}}
+    """
+    ...
+
 @typing.overload
 def update_in[K, V](
     d: collections.abc.Mapping[K, V],
@@ -333,61 +534,75 @@ def update_in[K, V](
     """
     ...
 
-@overload
-def valfilter[K: Hashable, V0, V1](
-    predicate: Callable[[V0], TypeIs[V1]],
-    d: Mapping[K, V0],
-    factory: Callable[[], dict[K, V1]] = dict,
-) -> dict[K, V1]: ...
-@overload
-def valfilter[K: Hashable, V0, V1](
-    predicate: Callable[[V0], TypeGuard[V1]],
-    d: Mapping[K, V0],
-    factory: Callable[[], dict[K, V1]] = dict,
-) -> dict[K, V1]: ...
-@overload
-def valfilter[K: Hashable, V](
-    predicate: Callable[[V], bool], d: Mapping[K, V]
-) -> dict[K, V]: ...
-@overload
-def valfilter[K: Hashable, V0, V1](
-    predicate: Callable[[V0], TypeIs[V1]],
-    d: Mapping[K, V0],
-    factory: Callable[[], MutableMapping[K, V1]],
-) -> MutableMapping[K, V1]: ...
-@overload
-def valfilter[K: Hashable, V0, V1](
-    predicate: Callable[[V0], TypeGuard[V1]],
-    d: Mapping[K, V0],
-    factory: Callable[[], MutableMapping[K, V1]],
-) -> MutableMapping[K, V1]: ...
-@overload
-def valfilter[K: Hashable, V0, V1](
-    predicate: Callable[[V0], bool],
-    d: Mapping[K, V0],
-    factory: Callable[[], MutableMapping[K, V1]],
-) -> MutableMapping[K, V1]: ...
-def valfilter[K: Hashable, V0, V1](
-    predicate: Callable[[V0], bool]
-    | Callable[[V0], TypeGuard[V1]]
-    | Callable[[V0], TypeIs[V1]],
-    d: Mapping[K, V0],
-    factory: Callable[[], MutableMapping[K, V1]] = dict,
-) -> MutableMapping[K, V1]: ...
-@overload
-def valmap[K: Hashable, V0, V1](
-    func: Callable[[V0], V1],
-    d: Mapping[K, V0],
-    factory: Callable[[], dict[K, V1]] = dict,
-) -> dict[K, V1]: ...
-@overload
-def valmap[K: Hashable, V0, V1](
-    func: Callable[[V0], V1],
-    d: Mapping[K, V0],
-    factory: Callable[[], MutableMapping[K, V1]],
-) -> MutableMapping[K, V1]: ...
-def valmap[K: Hashable, V0, V1](
-    func: Callable[[V0], V1],
-    d: Mapping[K, V0],
-    factory: Callable[[], MutableMapping[K, V1]] = dict,
-) -> MutableMapping[K, V1]: ...
+_KT_contra = TypeVar("_KT_contra", contravariant=True)
+_VT_co = TypeVar("_VT_co", covariant=True)
+
+class _SupportsGetItem(Protocol[_KT_contra, _VT_co]):
+    def __getitem__(self, key: _KT_contra, /) -> _VT_co: ...
+
+@typing.overload
+def get_in[K, V](
+    keys: collections.abc.Sequence[K],
+    coll: collections.abc.Sequence[V] | _SupportsGetItem[K, V],
+    default: None = None,
+    *,
+    no_default: Literal[True] = True,
+) -> V: ...
+@typing.overload
+def get_in[K, V](
+    keys: collections.abc.Sequence[K],
+    coll: collections.abc.Sequence[V] | _SupportsGetItem[K, V],
+    default: V,
+    no_default: Literal[True] = True,
+) -> V: ...
+@typing.overload
+def get_in[K, V0, V1](
+    keys: collections.abc.Sequence[K],
+    coll: collections.abc.Sequence[V0] | _SupportsGetItem[K, V0],
+    default: V1,
+    no_default: bool = False,
+) -> V0 | V1: ...
+@typing.overload
+def get_in[K, V](
+    keys: collections.abc.Sequence[K],
+    coll: collections.abc.Sequence[V] | _SupportsGetItem[K, V],
+    default: None = None,
+    no_default: bool = False,
+) -> V | None: ...
+def get_in[K, V0, V1](
+    keys: collections.abc.Sequence[K],
+    coll: collections.abc.Sequence[V0] | _SupportsGetItem[K, V0],
+    default: V1 | None = None,
+    no_default: bool = False,
+) -> V0 | V1 | None:
+    """Returns coll[i0][i1]...[iX] where [i0, i1, ..., iX]==keys.
+
+    If coll[i0][i1]...[iX] cannot be found, returns ``default``, unless
+    ``no_default`` is specified, then it raises KeyError or IndexError.
+
+    ``get_in`` is a generalization of ``operator.getitem`` for nested data
+    structures such as dictionaries and lists.
+
+    >>> transaction = {'name': 'Alice',
+    ...                'purchase': {'items': ['Apple', 'Orange'],
+    ...                             'costs': [0.50, 1.25]},
+    ...                'credit card': '5555-1234-1234-1234'}
+    >>> get_in(['purchase', 'items', 0], transaction)
+    'Apple'
+    >>> get_in(['name'], transaction)
+    'Alice'
+    >>> get_in(['purchase', 'total'], transaction)
+    >>> get_in(['purchase', 'items', 'apple'], transaction)
+    >>> get_in(['purchase', 'items', 10], transaction)
+    >>> get_in(['purchase', 'total'], transaction, 0)
+    0
+    >>> get_in(['y'], {}, no_default=True)
+    Traceback (most recent call last):
+        ...
+    KeyError: 'y'
+
+    See Also:
+        itertoolz.get
+        operator.getitem
+    """
+    ...

--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -1,6 +1,4 @@
 # pyright: reportExplicitAny = false
-from collections.abc import Callable, Hashable, Mapping, MutableMapping, Sequence
-from typing import overload, TypeGuard, TypeVar, Protocol, Literal
 import sys
 import collections.abc
 import typing
@@ -26,17 +24,20 @@ __all__ = (
     "get_in",
 )
 
-@overload
-def merge[K: Hashable, V](
-    *dicts: Mapping[K, V], factory: Callable[[], dict[K, V]] = dict
+@typing.overload
+def merge[K: collections.abc.Hashable, V](
+    *dicts: collections.abc.Mapping[K, V],
+    factory: collections.abc.Callable[[], dict[K, V]] = dict,
 ) -> dict[K, V]: ...
-@overload
-def merge[K: Hashable, V](
-    *dicts: Mapping[K, V], factory: Callable[[], MutableMapping[K, V]]
-) -> MutableMapping[K, V]: ...
-def merge[K: Hashable, V](
-    *dicts: Mapping[K, V], factory: Callable[[], MutableMapping[K, V]] = dict
-) -> MutableMapping[K, V]:
+@typing.overload
+def merge[K: collections.abc.Hashable, V](
+    *dicts: collections.abc.Mapping[K, V],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+) -> collections.abc.MutableMapping[K, V]: ...
+def merge[K: collections.abc.Hashable, V](
+    *dicts: collections.abc.Mapping[K, V],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+) -> collections.abc.MutableMapping[K, V]:
     """Merge a collection of dictionaries
 
     >>> merge({1: 'one'}, {2: 'two'})
@@ -52,23 +53,23 @@ def merge[K: Hashable, V](
     """
     ...
 
-@overload
-def merge_with[K: Hashable, V](
-    func: Callable[[Sequence[V]], V],
-    *dicts: Mapping[K, V],
-    factory: Callable[[], dict[K, V]] = dict,
+@typing.overload
+def merge_with[K: collections.abc.Hashable, V](
+    func: collections.abc.Callable[[collections.abc.Sequence[V]], V],
+    *dicts: collections.abc.Mapping[K, V],
+    factory: collections.abc.Callable[[], dict[K, V]] = dict,
 ) -> dict[K, V]: ...
-@overload
-def merge_with[K: Hashable, V](
-    func: Callable[[Sequence[V]], V],
-    *dicts: Mapping[K, V],
-    factory: Callable[[], MutableMapping[K, V]],
-) -> MutableMapping[K, V]: ...
-def merge_with[K: Hashable, V](
-    func: Callable[[Sequence[V]], V],
-    *dicts: Mapping[K, V],
-    factory: Callable[[], MutableMapping[K, V]] = dict,
-) -> MutableMapping[K, V]:
+@typing.overload
+def merge_with[K: collections.abc.Hashable, V](
+    func: collections.abc.Callable[[collections.abc.Sequence[V]], V],
+    *dicts: collections.abc.Mapping[K, V],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+) -> collections.abc.MutableMapping[K, V]: ...
+def merge_with[K: collections.abc.Hashable, V](
+    func: collections.abc.Callable[[collections.abc.Sequence[V]], V],
+    *dicts: collections.abc.Mapping[K, V],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+) -> collections.abc.MutableMapping[K, V]:
     """Merge dictionaries and apply function to combined values
 
     A key may occur in more than one dict, and all values mapped from the key
@@ -85,23 +86,23 @@ def merge_with[K: Hashable, V](
     """
     ...
 
-@overload
-def valmap[K: Hashable, V0, V1](
-    func: Callable[[V0], V1],
-    d: Mapping[K, V0],
-    factory: Callable[[], dict[K, V1]] = dict,
+@typing.overload
+def valmap[K: collections.abc.Hashable, V0, V1](
+    func: collections.abc.Callable[[V0], V1],
+    d: collections.abc.Mapping[K, V0],
+    factory: collections.abc.Callable[[], dict[K, V1]] = dict,
 ) -> dict[K, V1]: ...
-@overload
-def valmap[K: Hashable, V0, V1](
-    func: Callable[[V0], V1],
-    d: Mapping[K, V0],
-    factory: Callable[[], MutableMapping[K, V1]],
-) -> MutableMapping[K, V1]: ...
-def valmap[K: Hashable, V0, V1](
-    func: Callable[[V0], V1],
-    d: Mapping[K, V0],
-    factory: Callable[[], MutableMapping[K, V1]] = dict,
-) -> MutableMapping[K, V1]:
+@typing.overload
+def valmap[K: collections.abc.Hashable, V0, V1](
+    func: collections.abc.Callable[[V0], V1],
+    d: collections.abc.Mapping[K, V0],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
+) -> collections.abc.MutableMapping[K, V1]: ...
+def valmap[K: collections.abc.Hashable, V0, V1](
+    func: collections.abc.Callable[[V0], V1],
+    d: collections.abc.Mapping[K, V0],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
+) -> collections.abc.MutableMapping[K, V1]:
     """Apply function to values of dictionary
 
     >>> bills = {"Alice": [20, 15, 30], "Bob": [10, 35]}
@@ -114,23 +115,23 @@ def valmap[K: Hashable, V0, V1](
     """
     ...
 
-@overload
-def keymap[K0: Hashable, K1: Hashable, V](
-    func: Callable[[K0], K1],
-    d: Mapping[K0, V],
-    factory: Callable[[], dict[K1, V]] = dict,
+@typing.overload
+def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
+    func: collections.abc.Callable[[K0], K1],
+    d: collections.abc.Mapping[K0, V],
+    factory: collections.abc.Callable[[], dict[K1, V]] = dict,
 ) -> dict[K1, V]: ...
-@overload
-def keymap[K0: Hashable, K1: Hashable, V](
-    func: Callable[[K0], K1],
-    d: Mapping[K0, V],
-    factory: Callable[[], MutableMapping[K1, V]],
-) -> MutableMapping[K1, V]: ...
-def keymap[K0: Hashable, K1: Hashable, V](
-    func: Callable[[K0], K1],
-    d: Mapping[K0, V],
-    factory: Callable[[], MutableMapping[K1, V]] = dict,
-) -> MutableMapping[K1, V]:
+@typing.overload
+def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
+    func: collections.abc.Callable[[K0], K1],
+    d: collections.abc.Mapping[K0, V],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
+) -> collections.abc.MutableMapping[K1, V]: ...
+def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
+    func: collections.abc.Callable[[K0], K1],
+    d: collections.abc.Mapping[K0, V],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
+) -> collections.abc.MutableMapping[K1, V]:
     """Apply function to keys of dictionary
 
     >>> bills = {"Alice": [20, 15, 30], "Bob": [10, 35]}
@@ -143,23 +144,25 @@ def keymap[K0: Hashable, K1: Hashable, V](
     """
     ...
 
-@overload
-def itemmap[K0: Hashable, K1: Hashable, V0, V1](
-    func: Callable[[tuple[K0, V0]], tuple[K1, V1]],
-    d: Mapping[K0, V0],
-    factory: Callable[..., dict[K1, V1]] = dict,
+@typing.overload
+def itemmap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V0, V1](
+    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
+    d: collections.abc.Mapping[K0, V0],
+    factory: collections.abc.Callable[..., dict[K1, V1]] = dict,
 ) -> dict[K1, V1]: ...
-@overload
-def itemmap[K0: Hashable, K1: Hashable, V0, V1](
-    func: Callable[[tuple[K0, V0]], tuple[K1, V1]],
-    d: Mapping[K0, V0],
-    factory: Callable[..., MutableMapping[K1, V1]],
-) -> MutableMapping[K1, V1]: ...
-def itemmap[K0: Hashable, K1: Hashable, V0, V1](
-    func: Callable[[tuple[K0, V0]], tuple[K1, V1]],
-    d: Mapping[K0, V0],
-    factory: Callable[..., MutableMapping[K1, V1]] = dict,
-) -> MutableMapping[K1, V1]:
+@typing.overload
+def itemmap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V0, V1](
+    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
+    d: collections.abc.Mapping[K0, V0],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K1, V1]],
+) -> collections.abc.MutableMapping[K1, V1]: ...
+def itemmap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V0, V1](
+    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
+    d: collections.abc.Mapping[K0, V0],
+    factory: collections.abc.Callable[
+        ..., collections.abc.MutableMapping[K1, V1]
+    ] = dict,
+) -> collections.abc.MutableMapping[K1, V1]:
     """Apply function to items of dictionary
 
     >>> accountids = {"Alice": 10, "Bob": 20}
@@ -172,47 +175,47 @@ def itemmap[K0: Hashable, K1: Hashable, V0, V1](
     """
     ...
 
-@overload
-def valfilter[K: Hashable, V0, V1](
-    predicate: Callable[[V0], TypeIs[V1]],
-    d: Mapping[K, V0],
-    factory: Callable[[], dict[K, V1]] = dict,
+@typing.overload
+def valfilter[K: collections.abc.Hashable, V0, V1](
+    predicate: collections.abc.Callable[[V0], TypeIs[V1]],
+    d: collections.abc.Mapping[K, V0],
+    factory: collections.abc.Callable[[], dict[K, V1]] = dict,
 ) -> dict[K, V1]: ...
-@overload
-def valfilter[K: Hashable, V0, V1](
-    predicate: Callable[[V0], TypeGuard[V1]],
-    d: Mapping[K, V0],
-    factory: Callable[[], dict[K, V1]] = dict,
+@typing.overload
+def valfilter[K: collections.abc.Hashable, V0, V1](
+    predicate: collections.abc.Callable[[V0], typing.TypeGuard[V1]],
+    d: collections.abc.Mapping[K, V0],
+    factory: collections.abc.Callable[[], dict[K, V1]] = dict,
 ) -> dict[K, V1]: ...
-@overload
-def valfilter[K: Hashable, V](
-    predicate: Callable[[V], bool], d: Mapping[K, V]
+@typing.overload
+def valfilter[K: collections.abc.Hashable, V](
+    predicate: collections.abc.Callable[[V], bool], d: collections.abc.Mapping[K, V]
 ) -> dict[K, V]: ...
-@overload
-def valfilter[K: Hashable, V0, V1](
-    predicate: Callable[[V0], TypeIs[V1]],
-    d: Mapping[K, V0],
-    factory: Callable[[], MutableMapping[K, V1]],
-) -> MutableMapping[K, V1]: ...
-@overload
-def valfilter[K: Hashable, V0, V1](
-    predicate: Callable[[V0], TypeGuard[V1]],
-    d: Mapping[K, V0],
-    factory: Callable[[], MutableMapping[K, V1]],
-) -> MutableMapping[K, V1]: ...
-@overload
-def valfilter[K: Hashable, V0, V1](
-    predicate: Callable[[V0], bool],
-    d: Mapping[K, V0],
-    factory: Callable[[], MutableMapping[K, V1]],
-) -> MutableMapping[K, V1]: ...
-def valfilter[K: Hashable, V0, V1](
-    predicate: Callable[[V0], bool]
-    | Callable[[V0], TypeGuard[V1]]
-    | Callable[[V0], TypeIs[V1]],
-    d: Mapping[K, V0],
-    factory: Callable[[], MutableMapping[K, V1]] = dict,
-) -> MutableMapping[K, V1]:
+@typing.overload
+def valfilter[K: collections.abc.Hashable, V0, V1](
+    predicate: collections.abc.Callable[[V0], TypeIs[V1]],
+    d: collections.abc.Mapping[K, V0],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
+) -> collections.abc.MutableMapping[K, V1]: ...
+@typing.overload
+def valfilter[K: collections.abc.Hashable, V0, V1](
+    predicate: collections.abc.Callable[[V0], typing.TypeGuard[V1]],
+    d: collections.abc.Mapping[K, V0],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
+) -> collections.abc.MutableMapping[K, V1]: ...
+@typing.overload
+def valfilter[K: collections.abc.Hashable, V0, V1](
+    predicate: collections.abc.Callable[[V0], bool],
+    d: collections.abc.Mapping[K, V0],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
+) -> collections.abc.MutableMapping[K, V1]: ...
+def valfilter[K: collections.abc.Hashable, V0, V1](
+    predicate: collections.abc.Callable[[V0], bool]
+    | collections.abc.Callable[[V0], typing.TypeGuard[V1]]
+    | collections.abc.Callable[[V0], TypeIs[V1]],
+    d: collections.abc.Mapping[K, V0],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
+) -> collections.abc.MutableMapping[K, V1]:
     """Filter items in dictionary by value
 
     >>> iseven = lambda x: x % 2 == 0
@@ -227,49 +230,49 @@ def valfilter[K: Hashable, V0, V1](
     """
     ...
 
-@overload
-def keyfilter[K0: Hashable, K1: Hashable, V](
-    predicate: Callable[[K0], TypeIs[K1]],
-    d: Mapping[K0, V],
-    factory: Callable[[], dict[K1, V]] = dict,
+@typing.overload
+def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
+    predicate: collections.abc.Callable[[K0], TypeIs[K1]],
+    d: collections.abc.Mapping[K0, V],
+    factory: collections.abc.Callable[[], dict[K1, V]] = dict,
 ) -> dict[K1, V]: ...
-@overload
-def keyfilter[K0: Hashable, K1: Hashable, V](
-    predicate: Callable[[K0], TypeGuard[K1]],
-    d: Mapping[K0, V],
-    factory: Callable[[], dict[K1, V]] = dict,
+@typing.overload
+def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
+    predicate: collections.abc.Callable[[K0], typing.TypeGuard[K1]],
+    d: collections.abc.Mapping[K0, V],
+    factory: collections.abc.Callable[[], dict[K1, V]] = dict,
 ) -> dict[K1, V]: ...
-@overload
-def keyfilter[K: Hashable, V](
-    predicate: Callable[[K], bool],
-    d: Mapping[K, V],
-    factory: Callable[[], dict[K, V]] = dict,
+@typing.overload
+def keyfilter[K: collections.abc.Hashable, V](
+    predicate: collections.abc.Callable[[K], bool],
+    d: collections.abc.Mapping[K, V],
+    factory: collections.abc.Callable[[], dict[K, V]] = dict,
 ) -> dict[K, V]: ...
-@overload
-def keyfilter[K0: Hashable, K1: Hashable, V](
-    predicate: Callable[[K0], TypeIs[K1]],
-    d: Mapping[K0, V],
-    factory: Callable[[], MutableMapping[K1, V]],
-) -> MutableMapping[K1, V]: ...
-@overload
-def keyfilter[K0: Hashable, K1: Hashable, V](
-    predicate: Callable[[K0], TypeGuard[K1]],
-    d: Mapping[K0, V],
-    factory: Callable[[], MutableMapping[K1, V]],
-) -> MutableMapping[K1, V]: ...
-@overload
-def keyfilter[K0: Hashable, K1: Hashable, V](
-    predicate: Callable[[K0], bool],
-    d: Mapping[K0, V],
-    factory: Callable[[], MutableMapping[K1, V]],
-) -> MutableMapping[K1, V]: ...
-def keyfilter[K0: Hashable, K1: Hashable, V](
-    predicate: Callable[[K0], bool]
-    | Callable[[K0], TypeGuard[K1]]
-    | Callable[[K0], TypeIs[K1]],
-    d: Mapping[K0, V],
-    factory: Callable[[], MutableMapping[K1, V]] = dict,
-) -> MutableMapping[K1, V]:
+@typing.overload
+def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
+    predicate: collections.abc.Callable[[K0], TypeIs[K1]],
+    d: collections.abc.Mapping[K0, V],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
+) -> collections.abc.MutableMapping[K1, V]: ...
+@typing.overload
+def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
+    predicate: collections.abc.Callable[[K0], typing.TypeGuard[K1]],
+    d: collections.abc.Mapping[K0, V],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
+) -> collections.abc.MutableMapping[K1, V]: ...
+@typing.overload
+def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
+    predicate: collections.abc.Callable[[K0], bool],
+    d: collections.abc.Mapping[K0, V],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
+) -> collections.abc.MutableMapping[K1, V]: ...
+def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
+    predicate: collections.abc.Callable[[K0], bool]
+    | collections.abc.Callable[[K0], typing.TypeGuard[K1]]
+    | collections.abc.Callable[[K0], TypeIs[K1]],
+    d: collections.abc.Mapping[K0, V],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
+) -> collections.abc.MutableMapping[K1, V]:
     """Filter items in dictionary by key
 
     >>> iseven = lambda x: x % 2 == 0
@@ -284,49 +287,55 @@ def keyfilter[K0: Hashable, K1: Hashable, V](
     """
     ...
 
-@overload
-def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
-    predicate: Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
-    d: Mapping[K0, V0],
-    factory: Callable[[], dict[K1, V1]] = dict,
+@typing.overload
+def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
+    predicate: collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
+    d: collections.abc.Mapping[K0, V0],
+    factory: collections.abc.Callable[[], dict[K1, V1]] = dict,
 ) -> dict[K1, V1]: ...
-@overload
-def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
-    predicate: Callable[[tuple[K0, V0]], TypeGuard[tuple[K1, V1]]],
-    d: Mapping[K0, V0],
-    factory: Callable[[], dict[K1, V1]] = dict,
+@typing.overload
+def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
+    predicate: collections.abc.Callable[
+        [tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]
+    ],
+    d: collections.abc.Mapping[K0, V0],
+    factory: collections.abc.Callable[[], dict[K1, V1]] = dict,
 ) -> dict[K1, V1]: ...
-@overload
-def itemfilter[K: Hashable, V](
-    predicate: Callable[[tuple[K, V]], bool],
-    d: Mapping[K, V],
-    factory: Callable[[], dict[K, V]] = dict,
+@typing.overload
+def itemfilter[K: collections.abc.Hashable, V](
+    predicate: collections.abc.Callable[[tuple[K, V]], bool],
+    d: collections.abc.Mapping[K, V],
+    factory: collections.abc.Callable[[], dict[K, V]] = dict,
 ) -> dict[K, V]: ...
-@overload
-def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
-    predicate: Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
-    d: Mapping[K0, V0],
-    factory: Callable[[], MutableMapping[K1, V1]],
-) -> MutableMapping[K1, V1]: ...
-@overload
-def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
-    predicate: Callable[[tuple[K0, V0]], TypeGuard[tuple[K1, V1]]],
-    d: Mapping[K0, V0],
-    factory: Callable[[], MutableMapping[K1, V1]],
-) -> MutableMapping[K1, V1]: ...
-@overload
-def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
-    predicate: Callable[[tuple[K0, V0]], bool],
-    d: Mapping[K0, V0],
-    factory: Callable[[], MutableMapping[K1, V1]],
-) -> MutableMapping[K1, V1]: ...
-def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
-    predicate: Callable[[tuple[K0, V0]], bool]
-    | Callable[[tuple[K0, V0]], TypeGuard[tuple[K1, V1]]]
-    | Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
-    d: Mapping[K0, V0],
-    factory: Callable[[], MutableMapping[K1, V1]] = dict,
-) -> MutableMapping[K1, V1]:
+@typing.overload
+def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
+    predicate: collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
+    d: collections.abc.Mapping[K0, V0],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
+) -> collections.abc.MutableMapping[K1, V1]: ...
+@typing.overload
+def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
+    predicate: collections.abc.Callable[
+        [tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]
+    ],
+    d: collections.abc.Mapping[K0, V0],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
+) -> collections.abc.MutableMapping[K1, V1]: ...
+@typing.overload
+def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
+    predicate: collections.abc.Callable[[tuple[K0, V0]], bool],
+    d: collections.abc.Mapping[K0, V0],
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
+) -> collections.abc.MutableMapping[K1, V1]: ...
+def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
+    predicate: collections.abc.Callable[[tuple[K0, V0]], bool]
+    | collections.abc.Callable[[tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]]
+    | collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
+    d: collections.abc.Mapping[K0, V0],
+    factory: collections.abc.Callable[
+        [], collections.abc.MutableMapping[K1, V1]
+    ] = dict,
+) -> collections.abc.MutableMapping[K1, V1]:
     """Filter items in dictionary by item
 
     >>> def isvalid(item):
@@ -344,20 +353,26 @@ def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
     """
     ...
 
-@overload
-def assoc[K: Hashable, V](
-    d: Mapping[K, V], key: K, value: V, factory: Callable[[], dict[K, V]] = dict
-) -> dict[K, V]: ...
-@overload
-def assoc[K: Hashable, V](
-    d: Mapping[K, V], key: K, value: V, factory: Callable[[], MutableMapping[K, V]]
-) -> MutableMapping[K, V]: ...
-def assoc[K: Hashable, V](
-    d: Mapping[K, V],
+@typing.overload
+def assoc[K: collections.abc.Hashable, V](
+    d: collections.abc.Mapping[K, V],
     key: K,
     value: V,
-    factory: Callable[[], MutableMapping[K, V]] = dict,
-) -> MutableMapping[K, V]:
+    factory: collections.abc.Callable[[], dict[K, V]] = dict,
+) -> dict[K, V]: ...
+@typing.overload
+def assoc[K: collections.abc.Hashable, V](
+    d: collections.abc.Mapping[K, V],
+    key: K,
+    value: V,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+) -> collections.abc.MutableMapping[K, V]: ...
+def assoc[K: collections.abc.Hashable, V](
+    d: collections.abc.Mapping[K, V],
+    key: K,
+    value: V,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+) -> collections.abc.MutableMapping[K, V]:
     """Return a new dict with new key value pair
 
     New dict has d[key] set to value. Does not modify the initial dictionary.
@@ -369,17 +384,23 @@ def assoc[K: Hashable, V](
     """
     ...
 
-@overload
-def dissoc[K: Hashable, V](
-    d: Mapping[K, V], *keys: K, factory: Callable[[], dict[K, V]] = dict
+@typing.overload
+def dissoc[K: collections.abc.Hashable, V](
+    d: collections.abc.Mapping[K, V],
+    *keys: K,
+    factory: collections.abc.Callable[[], dict[K, V]] = dict,
 ) -> dict[K, V]: ...
-@overload
-def dissoc[K: Hashable, V](
-    d: Mapping[K, V], *keys: K, factory: Callable[[], MutableMapping[K, V]]
-) -> MutableMapping[K, V]: ...
-def dissoc[K: Hashable, V](
-    d: Mapping[K, V], *keys: K, factory: Callable[[], MutableMapping[K, V]] = dict
-) -> MutableMapping[K, V]:
+@typing.overload
+def dissoc[K: collections.abc.Hashable, V](
+    d: collections.abc.Mapping[K, V],
+    *keys: K,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+) -> collections.abc.MutableMapping[K, V]: ...
+def dissoc[K: collections.abc.Hashable, V](
+    d: collections.abc.Mapping[K, V],
+    *keys: K,
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+) -> collections.abc.MutableMapping[K, V]:
     """Return a new dict with the given key(s) removed.
 
     New dict has d[key] deleted for each supplied key.
@@ -534,10 +555,10 @@ def update_in[K, V](
     """
     ...
 
-_KT_contra = TypeVar("_KT_contra", contravariant=True)
-_VT_co = TypeVar("_VT_co", covariant=True)
+_KT_contra = typing.TypeVar("_KT_contra", contravariant=True)
+_VT_co = typing.TypeVar("_VT_co", covariant=True)
 
-class _SupportsGetItem(Protocol[_KT_contra, _VT_co]):
+class _SupportsGetItem(typing.Protocol[_KT_contra, _VT_co]):
     def __getitem__(self, key: _KT_contra, /) -> _VT_co: ...
 
 @typing.overload
@@ -546,14 +567,14 @@ def get_in[K, V](
     coll: collections.abc.Sequence[V] | _SupportsGetItem[K, V],
     default: None = None,
     *,
-    no_default: Literal[True] = True,
+    no_default: typing.Literal[True] = True,
 ) -> V: ...
 @typing.overload
 def get_in[K, V](
     keys: collections.abc.Sequence[K],
     coll: collections.abc.Sequence[V] | _SupportsGetItem[K, V],
     default: V,
-    no_default: Literal[True] = True,
+    no_default: typing.Literal[True] = True,
 ) -> V: ...
 @typing.overload
 def get_in[K, V0, V1](

--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -1,490 +1,273 @@
-# pyright: reportAny=false
-import collections.abc
+# pyright: reportExplicitAny = false
+from collections.abc import Callable, Hashable, Mapping, MutableMapping, Sequence
+from typing import Any, Literal, overload, Protocol, TypeGuard
 import sys
+import collections.abc
 import typing
 
 if sys.version_info >= (3, 13):
     from typing import TypeIs  # pyright: ignore[reportUnreachable]
 else:
     from typing_extensions import TypeIs
-
 __all__ = (
+    "assoc",
+    "assoc_in",
+    "dissoc",
+    "get_in",
+    "itemfilter",
+    "itemmap",
+    "keyfilter",
+    "keymap",
     "merge",
     "merge_with",
-    "valmap",
-    "keymap",
-    "itemmap",
-    "valfilter",
-    "keyfilter",
-    "itemfilter",
-    "assoc",
-    "dissoc",
-    "assoc_in",
     "update_in",
-    "get_in",
+    "valfilter",
+    "valmap",
 )
 
-@typing.overload
-def merge[K, V](*dicts: collections.abc.Mapping[K, V]) -> dict[K, V]: ...
-@typing.overload
-def merge[K, V](
-    *dicts: collections.abc.Mapping[K, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> collections.abc.MutableMapping[K, V]: ...
-def merge[K, V](
-    *dicts: collections.abc.Mapping[K, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
-) -> collections.abc.MutableMapping[K, V]:
-    """Merge a collection of dictionaries
+class SupportsGetItem[K: Hashable, V](Protocol):
+    def __getitem__(self, key: K, /) -> V: ...
 
-    >>> merge({1: 'one'}, {2: 'two'})
-    {1: 'one', 2: 'two'}
-
-    Later dictionaries have precedence
-
-    >>> merge({1: 2, 3: 4}, {3: 3, 4: 4})
-    {1: 2, 3: 3, 4: 4}
-
-    See Also:
-        merge_with
-    """
-    ...
-
-@typing.overload
-def merge_with[K, V](
-    func: collections.abc.Callable[[list[V]], V],
-    *dicts: collections.abc.Mapping[K, V],
+@overload
+def assoc[K: Hashable, V](
+    d: Mapping[K, V], key: K, value: V, factory: Callable[[], dict[K, V]] = dict
 ) -> dict[K, V]: ...
-@typing.overload
-def merge_with[K, V](
-    func: collections.abc.Callable[[list[V]], V],
-    *dicts: collections.abc.Mapping[K, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> collections.abc.MutableMapping[K, V]: ...
-def merge_with[K, V](
-    func: collections.abc.Callable[[list[V]], V],
-    *dicts: collections.abc.Mapping[K, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
-) -> collections.abc.MutableMapping[K, V]:
-    """Merge dictionaries and apply function to combined values
-
-    A key may occur in more than one dict, and all values mapped from the key
-    will be passed to the function as a list, such as func([val1, val2, ...]).
-
-    >>> merge_with(sum, {1: 1, 2: 2}, {1: 10, 2: 20})
-    {1: 11, 2: 22}
-
-    >>> merge_with(first, {1: 1, 2: 2}, {2: 20, 3: 30})  # doctest: +SKIP
-    {1: 1, 2: 2, 3: 30}
-
-    See Also:
-        merge
-    """
-    ...
-
-@typing.overload
-def valmap[K, V0, V1](
-    func: collections.abc.Callable[[V0], V1],
-    d: collections.abc.Mapping[K, V0],
-) -> dict[K, V1]: ...
-@typing.overload
-def valmap[K, V0, V1](
-    func: collections.abc.Callable[[V0], V1],
-    d: collections.abc.Mapping[K, V0],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
-) -> collections.abc.MutableMapping[K, V1]: ...
-def valmap[K, V0, V1](
-    func: collections.abc.Callable[[V0], V1],
-    d: collections.abc.Mapping[K, V0],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
-) -> collections.abc.MutableMapping[K, V1]:
-    """Apply function to values of dictionary
-
-    >>> bills = {"Alice": [20, 15, 30], "Bob": [10, 35]}
-    >>> valmap(sum, bills)  # doctest: +SKIP
-    {'Alice': 65, 'Bob': 45}
-
-    See Also:
-        keymap
-        itemmap
-    """
-    ...
-
-@typing.overload
-def keymap[K0, K1, V](
-    func: collections.abc.Callable[[K0], K1],
-    d: collections.abc.Mapping[K0, V],
-) -> dict[K1, V]: ...
-@typing.overload
-def keymap[K0, K1, V](
-    func: collections.abc.Callable[[K0], K1],
-    d: collections.abc.Mapping[K0, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
-) -> collections.abc.MutableMapping[K1, V]: ...
-def keymap[K0, K1, V](
-    func: collections.abc.Callable[[K0], K1],
-    d: collections.abc.Mapping[K0, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
-) -> collections.abc.MutableMapping[K1, V]:
-    """Apply function to keys of dictionary
-
-    >>> bills = {"Alice": [20, 15, 30], "Bob": [10, 35]}
-    >>> keymap(str.lower, bills)  # doctest: +SKIP
-    {'alice': [20, 15, 30], 'bob': [10, 35]}
-
-    See Also:
-        valmap
-        itemmap
-    """
-    ...
-
-@typing.overload
-def itemmap[K0, V0, K1, V1](
-    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
-    d: collections.abc.Mapping[K0, V0],
-) -> dict[K1, V1]: ...
-@typing.overload
-def itemmap[K0, V0, K1, V1](
-    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
-    d: collections.abc.Mapping[K0, V0],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
-) -> collections.abc.MutableMapping[K1, V1]: ...
-def itemmap[K0, V0, K1, V1](
-    func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
-    d: collections.abc.Mapping[K0, V0],
-    *,
-    factory: collections.abc.Callable[
-        [], collections.abc.MutableMapping[K1, V1]
-    ] = dict,
-) -> collections.abc.MutableMapping[K1, V1]:
-    """Apply function to items of dictionary
-
-    >>> accountids = {"Alice": 10, "Bob": 20}
-    >>> itemmap(reversed, accountids)  # doctest: +SKIP
-    {10: "Alice", 20: "Bob"}
-
-    See Also:
-        keymap
-        valmap
-    """
-    ...
-
-@typing.overload
-def valfilter[K, V, R](
-    predicate: collections.abc.Callable[[V], TypeIs[R]],
-    d: collections.abc.Mapping[K, V],
-) -> dict[K, R]: ...
-@typing.overload
-def valfilter[K, V, R](
-    predicate: collections.abc.Callable[[V], typing.TypeGuard[R]],
-    d: collections.abc.Mapping[K, V],
-) -> dict[K, R]: ...
-@typing.overload
-def valfilter[K, V](
-    predicate: collections.abc.Callable[[V], bool],
-    d: collections.abc.Mapping[K, V],
-) -> dict[K, V]: ...
-@typing.overload
-def valfilter[K, V, R](
-    predicate: collections.abc.Callable[[V], TypeIs[R]],
-    d: collections.abc.Mapping[K, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, R]],
-) -> collections.abc.MutableMapping[K, R]: ...
-@typing.overload
-def valfilter[K, V, R](
-    predicate: collections.abc.Callable[[V], typing.TypeGuard[R]],
-    d: collections.abc.Mapping[K, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, R]],
-) -> collections.abc.MutableMapping[K, R]: ...
-@typing.overload
-def valfilter[K, V](
-    predicate: collections.abc.Callable[[V], bool],
-    d: collections.abc.Mapping[K, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> collections.abc.MutableMapping[K, V]: ...
-def valfilter[K, V, R](
-    predicate: collections.abc.Callable[[V], bool]
-    | collections.abc.Callable[[V], typing.TypeGuard[R]],
-    d: collections.abc.Mapping[K, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
-) -> collections.abc.MutableMapping[K, V]:
-    """Filter items in dictionary by value
-
-    >>> iseven = lambda x: x % 2 == 0
-    >>> d = {1: 2, 2: 3, 3: 4, 4: 5}
-    >>> valfilter(iseven, d)
-    {1: 2, 3: 4}
-
-    See Also:
-        keyfilter
-        itemfilter
-        valmap
-    """
-    ...
-
-@typing.overload
-def keyfilter[K, V, R](
-    predicate: collections.abc.Callable[[K], TypeIs[R]],
-    d: collections.abc.Mapping[K, V],
-) -> dict[R, V]: ...
-@typing.overload
-def keyfilter[K, V, R](
-    predicate: collections.abc.Callable[[K], typing.TypeGuard[R]],
-    d: collections.abc.Mapping[K, V],
-) -> dict[R, V]: ...
-@typing.overload
-def keyfilter[K, V](
-    predicate: collections.abc.Callable[[K], bool],
-    d: collections.abc.Mapping[K, V],
-) -> dict[K, V]: ...
-@typing.overload
-def keyfilter[K, V, R](
-    predicate: collections.abc.Callable[[K], TypeIs[R]],
-    d: collections.abc.Mapping[K, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[R, V]],
-) -> collections.abc.MutableMapping[R, V]: ...
-@typing.overload
-def keyfilter[K, V, R](
-    predicate: collections.abc.Callable[[K], typing.TypeGuard[R]],
-    d: collections.abc.Mapping[K, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[R, V]],
-) -> collections.abc.MutableMapping[R, V]: ...
-@typing.overload
-def keyfilter[K, V](
-    predicate: collections.abc.Callable[[K], bool],
-    d: collections.abc.Mapping[K, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> collections.abc.MutableMapping[K, V]: ...
-def keyfilter[K, V, R](
-    predicate: collections.abc.Callable[[K], bool]
-    | collections.abc.Callable[[K], typing.TypeGuard[R]],
-    d: collections.abc.Mapping[K, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
-) -> collections.abc.MutableMapping[K, V]:
-    """Filter items in dictionary by key
-
-    >>> iseven = lambda x: x % 2 == 0
-    >>> d = {1: 2, 2: 3, 3: 4, 4: 5}
-    >>> keyfilter(iseven, d)
-    {2: 3, 4: 5}
-
-    See Also:
-        valfilter
-        itemfilter
-        keymap
-    """
-    ...
-
-@typing.overload
-def itemfilter[K, V, K1, V1](
-    predicate: collections.abc.Callable[[tuple[K, V]], TypeIs[tuple[K1, V1]]],
-    d: collections.abc.Mapping[K, V],
-) -> dict[K1, V1]: ...
-@typing.overload
-def itemfilter[K, V, K1, V1](
-    predicate: collections.abc.Callable[[tuple[K, V]], typing.TypeGuard[tuple[K1, V1]]],
-    d: collections.abc.Mapping[K, V],
-) -> dict[K1, V1]: ...
-@typing.overload
-def itemfilter[K, V](
-    predicate: collections.abc.Callable[[tuple[K, V]], bool],
-    d: collections.abc.Mapping[K, V],
-) -> dict[K, V]: ...
-@typing.overload
-def itemfilter[K, V, K1, V1](
-    predicate: collections.abc.Callable[[tuple[K, V]], TypeIs[tuple[K1, V1]]],
-    d: collections.abc.Mapping[K, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
-) -> collections.abc.MutableMapping[K1, V1]: ...
-@typing.overload
-def itemfilter[K, V, K1, V1](
-    predicate: collections.abc.Callable[[tuple[K, V]], typing.TypeGuard[tuple[K1, V1]]],
-    d: collections.abc.Mapping[K, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
-) -> collections.abc.MutableMapping[K1, V1]: ...
-@typing.overload
-def itemfilter[K, V](
-    predicate: collections.abc.Callable[[tuple[K, V]], bool],
-    d: collections.abc.Mapping[K, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> collections.abc.MutableMapping[K, V]: ...
-def itemfilter[K, V, K1, V1](
-    predicate: collections.abc.Callable[[tuple[K, V]], bool]
-    | collections.abc.Callable[[tuple[K, V]], typing.TypeGuard[tuple[K1, V1]]],
-    d: collections.abc.Mapping[K, V],
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
-) -> collections.abc.MutableMapping[K, V]:
-    """Filter items in dictionary by item
-
-    >>> def isvalid(item):
-    ...     k, v = item
-    ...     return k % 2 == 0 and v < 4
-
-    >>> d = {1: 2, 2: 3, 3: 4, 4: 5}
-    >>> itemfilter(isvalid, d)
-    {2: 3}
-
-    See Also:
-        keyfilter
-        valfilter
-        itemmap
-    """
-    ...
-
-@typing.overload
-def assoc[K, V](
-    d: collections.abc.Mapping[K, V],
+@overload
+def assoc[K: Hashable, V](
+    d: Mapping[K, V], key: K, value: V, factory: Callable[[], MutableMapping[K, V]]
+) -> MutableMapping[K, V]: ...
+def assoc[K: Hashable, V](
+    d: Mapping[K, V],
     key: K,
     value: V,
-) -> dict[K, V]: ...
-@typing.overload
-def assoc[K, V](
-    d: collections.abc.Mapping[K, V],
-    key: K,
-    value: V,
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> collections.abc.MutableMapping[K, V]: ...
-def assoc[K, V](
-    d: collections.abc.Mapping[K, V],
-    key: K,
-    value: V,
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
-) -> collections.abc.MutableMapping[K, V]:
-    """Return a new dict with new key value pair
-
-    New dict has d[key] set to value. Does not modify the initial dictionary.
-
-    >>> assoc({'x': 1}, 'x', 2)
-    {'x': 2}
-    >>> assoc({'x': 1}, 'y', 3)   # doctest: +SKIP
-    {'x': 1, 'y': 3}
-    """
-    ...
-
-@typing.overload
-def dissoc[K, V](
-    d: collections.abc.Mapping[K, V],
-    *keys: K,
-) -> dict[K, V]: ...
-@typing.overload
-def dissoc[K, V](
-    d: collections.abc.Mapping[K, V],
-    *keys: K,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> collections.abc.MutableMapping[K, V]: ...
-def dissoc[K, V](
-    d: collections.abc.Mapping[K, V],
-    *keys: K,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
-) -> collections.abc.MutableMapping[K, V]:
-    """Return a new dict with the given key(s) removed.
-
-    New dict has d[key] deleted for each supplied key.
-    Does not modify the initial dictionary.
-
-    >>> dissoc({'x': 1, 'y': 2}, 'y')
-    {'x': 1}
-    >>> dissoc({'x': 1, 'y': 2}, 'y', 'x')
-    {}
-    >>> dissoc({'x': 1}, 'y') # Ignores missing keys
-    {'x': 1}
-    """
-    ...
-
-# Overloads for nested dictionaries with tuple keys (2-level nesting)
-@typing.overload
+    factory: Callable[[], MutableMapping[K, V]] = dict,
+) -> MutableMapping[K, V]: ...
+@overload
 def assoc_in[K1, K2, V1, V2](
-    d: collections.abc.Mapping[K1, collections.abc.Mapping[K2, V2] | V1],
-    keys: tuple[K1, K2],
-    value: V2,
+    d: Mapping[K1, Mapping[K2, V2] | V1], keys: tuple[K1, K2], value: V2
 ) -> dict[K1, dict[K2, V2] | V1 | V2]: ...
-@typing.overload
+@overload
 def assoc_in[K1, K2, V1, V2](
-    d: collections.abc.Mapping[K1, collections.abc.Mapping[K2, V2] | V1],
+    d: Mapping[K1, Mapping[K2, V2] | V1],
     keys: tuple[K1, K2],
     value: V2,
     *,
-    factory: collections.abc.Callable[
-        [], collections.abc.MutableMapping[K1, typing.Any]
-    ],
-) -> collections.abc.MutableMapping[K1, typing.Any]: ...
-
-# Overloads for nested dictionaries with tuple keys (3-level nesting)
-@typing.overload
+    factory: Callable[[], MutableMapping[K1, Any]],
+) -> MutableMapping[K1, Any]: ...
+@overload
 def assoc_in[K1, K2, K3, V1, V2, V3](
-    d: collections.abc.Mapping[
-        K1, collections.abc.Mapping[K2, collections.abc.Mapping[K3, V3] | V2] | V1
-    ],
+    d: Mapping[K1, Mapping[K2, Mapping[K3, V3] | V2] | V1],
     keys: tuple[K1, K2, K3],
     value: V3,
 ) -> dict[K1, dict[K2, dict[K3, V3] | V2 | V3] | V1 | V3]: ...
-@typing.overload
+@overload
 def assoc_in[K1, K2, K3, V1, V2, V3](
-    d: collections.abc.Mapping[
-        K1, collections.abc.Mapping[K2, collections.abc.Mapping[K3, V3] | V2] | V1
-    ],
+    d: Mapping[K1, Mapping[K2, Mapping[K3, V3] | V2] | V1],
     keys: tuple[K1, K2, K3],
     value: V3,
     *,
-    factory: collections.abc.Callable[
-        [], collections.abc.MutableMapping[K1, typing.Any]
-    ],
-) -> collections.abc.MutableMapping[K1, typing.Any]: ...
-
-# General overloads for backwards compatibility
-@typing.overload
+    factory: Callable[[], MutableMapping[K1, Any]],
+) -> MutableMapping[K1, Any]: ...
+@overload
+def assoc_in[K, V](d: Mapping[K, V], keys: Sequence[K], value: V) -> dict[K, V]: ...
+@overload
 def assoc_in[K, V](
-    d: collections.abc.Mapping[K, V],
-    keys: collections.abc.Iterable[K] | K,
+    d: Mapping[K, V],
+    keys: Sequence[K],
     value: V,
+    *,
+    factory: Callable[[], MutableMapping[K, V]],
+) -> MutableMapping[K, V]: ...
+def assoc_in[K, V](
+    d: Mapping[K, V],
+    keys: Sequence[K],
+    value: V,
+    *,
+    factory: Callable[[], MutableMapping[K, V]] = dict,
+) -> MutableMapping[K, V]: ...
+@overload
+def dissoc[K: Hashable, V](
+    d: Mapping[K, V], *keys: K, factory: Callable[[], dict[K, V]] = dict
 ) -> dict[K, V]: ...
-@typing.overload
-def assoc_in[K, V](
-    d: collections.abc.Mapping[K, V],
-    keys: collections.abc.Iterable[K] | K,
-    value: V,
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> collections.abc.MutableMapping[K, V]: ...
-def assoc_in[K, V](
-    d: collections.abc.Mapping[K, V],
-    keys: collections.abc.Iterable[K] | K,
-    value: V,
-    *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
-) -> collections.abc.MutableMapping[K, V]:
-    """Return a new dict with new, potentially nested, key value pair
-
-    >>> purchase = {'name': 'Alice',
-    ...             'order': {'items': ['Apple', 'Orange'],
-    ...                       'costs': [0.50, 1.25]},
-    ...             'credit card': '5555-1234-1234-1234'}
-    >>> assoc_in(purchase, ['order', 'costs'], [0.25, 1.00]) # doctest: +SKIP
-    {'credit card': '5555-1234-1234-1234',
-     'name': 'Alice',
-     'order': {'costs': [0.25, 1.00], 'items': ['Apple', 'Orange']}}
-    """
-    ...
-
+@overload
+def dissoc[K: Hashable, V](
+    d: Mapping[K, V], *keys: K, factory: Callable[[], MutableMapping[K, V]]
+) -> MutableMapping[K, V]: ...
+def dissoc[K: Hashable, V](
+    d: Mapping[K, V], *keys: K, factory: Callable[[], MutableMapping[K, V]] = dict
+) -> MutableMapping[K, V]: ...
+@overload
+def get_in[K: Hashable, V](
+    keys: Sequence[K],
+    coll: SupportsGetItem[K, V],
+    default: None = None,
+    no_default: Literal[True] = True,
+) -> V: ...
+@overload
+def get_in[K: Hashable, V](
+    keys: Sequence[K],
+    coll: SupportsGetItem[K, V],
+    default: None = None,
+    no_default: bool = False,
+) -> V | None: ...
+@overload
+def get_in[K: Hashable, V](
+    keys: Sequence[K], coll: SupportsGetItem[K, V], default: V, no_default: bool = False
+) -> V: ...
+def get_in[K: Hashable, V](
+    keys: Sequence[K],
+    coll: SupportsGetItem[K, V],
+    default: V | None = None,
+    no_default: bool = False,
+) -> V | None: ...
+@overload
+def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
+    predicate: Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
+    d: Mapping[K0, V0],
+    factory: Callable[[], dict[K1, V1]] = dict,
+) -> dict[K1, V1]: ...
+@overload
+def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
+    predicate: Callable[[tuple[K0, V0]], TypeGuard[tuple[K1, V1]]],
+    d: Mapping[K0, V0],
+    factory: Callable[[], dict[K1, V1]] = dict,
+) -> dict[K1, V1]: ...
+@overload
+def itemfilter[K: Hashable, V](
+    predicate: Callable[[tuple[K, V]], bool],
+    d: Mapping[K, V],
+    factory: Callable[[], dict[K, V]] = dict,
+) -> dict[K, V]: ...
+@overload
+def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
+    predicate: Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
+    d: Mapping[K0, V0],
+    factory: Callable[[], MutableMapping[K1, V1]],
+) -> MutableMapping[K1, V1]: ...
+@overload
+def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
+    predicate: Callable[[tuple[K0, V0]], TypeGuard[tuple[K1, V1]]],
+    d: Mapping[K0, V0],
+    factory: Callable[[], MutableMapping[K1, V1]],
+) -> MutableMapping[K1, V1]: ...
+@overload
+def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
+    predicate: Callable[[tuple[K0, V0]], bool],
+    d: Mapping[K0, V0],
+    factory: Callable[[], MutableMapping[K1, V1]],
+) -> MutableMapping[K1, V1]: ...
+def itemfilter[K0: Hashable, V0, K1: Hashable, V1](
+    predicate: Callable[[tuple[K0, V0]], bool]
+    | Callable[[tuple[K0, V0]], TypeGuard[tuple[K1, V1]]]
+    | Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
+    d: Mapping[K0, V0],
+    factory: Callable[[], MutableMapping[K1, V1]] = dict,
+) -> MutableMapping[K1, V1]: ...
+@overload
+def itemmap[K0: Hashable, K1: Hashable, V0, V1](
+    func: Callable[[tuple[K0, V0]], tuple[K1, V1]],
+    d: Mapping[K0, V0],
+    factory: Callable[..., dict[K1, V1]] = dict,
+) -> dict[K1, V1]: ...
+@overload
+def itemmap[K0: Hashable, K1: Hashable, V0, V1](
+    func: Callable[[tuple[K0, V0]], tuple[K1, V1]],
+    d: Mapping[K0, V0],
+    factory: Callable[..., MutableMapping[K1, V1]],
+) -> MutableMapping[K1, V1]: ...
+def itemmap[K0: Hashable, K1: Hashable, V0, V1](
+    func: Callable[[tuple[K0, V0]], tuple[K1, V1]],
+    d: Mapping[K0, V0],
+    factory: Callable[..., MutableMapping[K1, V1]] = dict,
+) -> MutableMapping[K1, V1]: ...
+@overload
+def keyfilter[K0: Hashable, K1: Hashable, V](
+    predicate: Callable[[K0], TypeIs[K1]],
+    d: Mapping[K0, V],
+    factory: Callable[[], dict[K1, V]] = dict,
+) -> dict[K1, V]: ...
+@overload
+def keyfilter[K0: Hashable, K1: Hashable, V](
+    predicate: Callable[[K0], TypeGuard[K1]],
+    d: Mapping[K0, V],
+    factory: Callable[[], dict[K1, V]] = dict,
+) -> dict[K1, V]: ...
+@overload
+def keyfilter[K: Hashable, V](
+    predicate: Callable[[K], bool],
+    d: Mapping[K, V],
+    factory: Callable[[], dict[K, V]] = dict,
+) -> dict[K, V]: ...
+@overload
+def keyfilter[K0: Hashable, K1: Hashable, V](
+    predicate: Callable[[K0], TypeIs[K1]],
+    d: Mapping[K0, V],
+    factory: Callable[[], MutableMapping[K1, V]],
+) -> MutableMapping[K1, V]: ...
+@overload
+def keyfilter[K0: Hashable, K1: Hashable, V](
+    predicate: Callable[[K0], TypeGuard[K1]],
+    d: Mapping[K0, V],
+    factory: Callable[[], MutableMapping[K1, V]],
+) -> MutableMapping[K1, V]: ...
+@overload
+def keyfilter[K0: Hashable, K1: Hashable, V](
+    predicate: Callable[[K0], bool],
+    d: Mapping[K0, V],
+    factory: Callable[[], MutableMapping[K1, V]],
+) -> MutableMapping[K1, V]: ...
+def keyfilter[K0: Hashable, K1: Hashable, V](
+    predicate: Callable[[K0], bool]
+    | Callable[[K0], TypeGuard[K1]]
+    | Callable[[K0], TypeIs[K1]],
+    d: Mapping[K0, V],
+    factory: Callable[[], MutableMapping[K1, V]] = dict,
+) -> MutableMapping[K1, V]: ...
+@overload
+def keymap[K0: Hashable, K1: Hashable, V](
+    func: Callable[[K0], K1],
+    d: Mapping[K0, V],
+    factory: Callable[[], dict[K1, V]] = dict,
+) -> dict[K1, V]: ...
+@overload
+def keymap[K0: Hashable, K1: Hashable, V](
+    func: Callable[[K0], K1],
+    d: Mapping[K0, V],
+    factory: Callable[[], MutableMapping[K1, V]],
+) -> MutableMapping[K1, V]: ...
+def keymap[K0: Hashable, K1: Hashable, V](
+    func: Callable[[K0], K1],
+    d: Mapping[K0, V],
+    factory: Callable[[], MutableMapping[K1, V]] = dict,
+) -> MutableMapping[K1, V]: ...
+@overload
+def merge[K: Hashable, V](
+    *dicts: Mapping[K, V], factory: Callable[[], dict[K, V]] = dict
+) -> dict[K, V]: ...
+@overload
+def merge[K: Hashable, V](
+    *dicts: Mapping[K, V], factory: Callable[[], MutableMapping[K, V]]
+) -> MutableMapping[K, V]: ...
+def merge[K: Hashable, V](
+    *dicts: Mapping[K, V], factory: Callable[[], MutableMapping[K, V]] = dict
+) -> MutableMapping[K, V]: ...
+@overload
+def merge_with[K: Hashable, V](
+    func: Callable[[Sequence[V]], V],
+    *dicts: Mapping[K, V],
+    factory: Callable[[], dict[K, V]] = dict,
+) -> dict[K, V]: ...
+@overload
+def merge_with[K: Hashable, V](
+    func: Callable[[Sequence[V]], V],
+    *dicts: Mapping[K, V],
+    factory: Callable[[], MutableMapping[K, V]],
+) -> MutableMapping[K, V]: ...
+def merge_with[K: Hashable, V](
+    func: Callable[[Sequence[V]], V],
+    *dicts: Mapping[K, V],
+    factory: Callable[[], MutableMapping[K, V]] = dict,
+) -> MutableMapping[K, V]: ...
 @typing.overload
 def update_in[K, V](
     d: collections.abc.Mapping[K, V],
@@ -550,61 +333,61 @@ def update_in[K, V](
     """
     ...
 
-@typing.overload
-def get_in[K, V, D](
-    keys: collections.abc.Iterable[K] | K,
-    coll: collections.abc.Iterable[V] | collections.abc.Mapping[K, V],
-    default: V,
-    no_default: bool = ...,
-) -> V: ...
-@typing.overload
-def get_in[K, V, D](
-    keys: collections.abc.Iterable[K] | K,
-    coll: collections.abc.Iterable[V] | collections.abc.Mapping[K, V],
-    default: D = ...,
-    no_default: bool = ...,
-) -> V | D: ...
-@typing.overload
-def get_in[K, V](
-    keys: collections.abc.Iterable[K] | K,
-    coll: collections.abc.Iterable[V] | collections.abc.Mapping[K, V],
-    default: typing.Any = ...,
-    no_default: bool = ...,
-) -> typing.Any: ...
-def get_in[K, V](
-    keys: collections.abc.Iterable[K] | K,
-    coll: collections.abc.Iterable[V] | collections.abc.Mapping[K, V],
-    default: typing.Any = None,
-    no_default: bool = False,
-) -> typing.Any:
-    """Returns coll[i0][i1]...[iX] where [i0, i1, ..., iX]==keys.
-
-    If coll[i0][i1]...[iX] cannot be found, returns ``default``, unless
-    ``no_default`` is specified, then it raises KeyError or IndexError.
-
-    ``get_in`` is a generalization of ``operator.getitem`` for nested data
-    structures such as dictionaries and lists.
-
-    >>> transaction = {'name': 'Alice',
-    ...                'purchase': {'items': ['Apple', 'Orange'],
-    ...                             'costs': [0.50, 1.25]},
-    ...                'credit card': '5555-1234-1234-1234'}
-    >>> get_in(['purchase', 'items', 0], transaction)
-    'Apple'
-    >>> get_in(['name'], transaction)
-    'Alice'
-    >>> get_in(['purchase', 'total'], transaction)
-    >>> get_in(['purchase', 'items', 'apple'], transaction)
-    >>> get_in(['purchase', 'items', 10], transaction)
-    >>> get_in(['purchase', 'total'], transaction, 0)
-    0
-    >>> get_in(['y'], {}, no_default=True)
-    Traceback (most recent call last):
-        ...
-    KeyError: 'y'
-
-    See Also:
-        itertoolz.get
-        operator.getitem
-    """
-    ...
+@overload
+def valfilter[K: Hashable, V0, V1](
+    predicate: Callable[[V0], TypeIs[V1]],
+    d: Mapping[K, V0],
+    factory: Callable[[], dict[K, V1]] = dict,
+) -> dict[K, V1]: ...
+@overload
+def valfilter[K: Hashable, V0, V1](
+    predicate: Callable[[V0], TypeGuard[V1]],
+    d: Mapping[K, V0],
+    factory: Callable[[], dict[K, V1]] = dict,
+) -> dict[K, V1]: ...
+@overload
+def valfilter[K: Hashable, V](
+    predicate: Callable[[V], bool], d: Mapping[K, V]
+) -> dict[K, V]: ...
+@overload
+def valfilter[K: Hashable, V0, V1](
+    predicate: Callable[[V0], TypeIs[V1]],
+    d: Mapping[K, V0],
+    factory: Callable[[], MutableMapping[K, V1]],
+) -> MutableMapping[K, V1]: ...
+@overload
+def valfilter[K: Hashable, V0, V1](
+    predicate: Callable[[V0], TypeGuard[V1]],
+    d: Mapping[K, V0],
+    factory: Callable[[], MutableMapping[K, V1]],
+) -> MutableMapping[K, V1]: ...
+@overload
+def valfilter[K: Hashable, V0, V1](
+    predicate: Callable[[V0], bool],
+    d: Mapping[K, V0],
+    factory: Callable[[], MutableMapping[K, V1]],
+) -> MutableMapping[K, V1]: ...
+def valfilter[K: Hashable, V0, V1](
+    predicate: Callable[[V0], bool]
+    | Callable[[V0], TypeGuard[V1]]
+    | Callable[[V0], TypeIs[V1]],
+    d: Mapping[K, V0],
+    factory: Callable[[], MutableMapping[K, V1]] = dict,
+) -> MutableMapping[K, V1]: ...
+@overload
+def valmap[K: Hashable, V0, V1](
+    func: Callable[[V0], V1],
+    d: Mapping[K, V0],
+    factory: Callable[[], dict[K, V1]] = dict,
+) -> dict[K, V1]: ...
+@overload
+def valmap[K: Hashable, V0, V1](
+    func: Callable[[V0], V1],
+    d: Mapping[K, V0],
+    factory: Callable[[], MutableMapping[K, V1]],
+) -> MutableMapping[K, V1]: ...
+def valmap[K: Hashable, V0, V1](
+    func: Callable[[V0], V1],
+    d: Mapping[K, V0],
+    factory: Callable[[], MutableMapping[K, V1]] = dict,
+) -> MutableMapping[K, V1]: ...

--- a/tests/test_dicttoolz.py
+++ b/tests/test_dicttoolz.py
@@ -423,5 +423,7 @@ class TestGetIn:
     def test_no_default_raises(self) -> None:
         """get_in with no_default=True should raise KeyError."""
 
+        coll: dict[str, int] = {}
+
         with pytest.raises(KeyError):
-            _ = dt.get_in(["y"], {}, no_default=True)
+            _ = dt.get_in(["y"], coll, no_default=True)


### PR DESCRIPTION
# `# pyright: reportExplicitAny = false` 
I think when the annotation is `typing.Any`, basedPyright doesn't notice it. IDK if that is intentional.

# Why is the format so different?
I have not fully automated the creation of stubfiles.
See https://github.com/hunterhogan/hunterMakesPy/blob/3e3dc25f846743c59ecd8ec878a2496cda611031/hunterMakesPy/assimilate/exportStub.py 
and https://github.com/hunterhogan/Z0Z_tools/issues/27

Maybe there is a stubgen that will create the stubs without ImportFrom and call everything with attribute access: IDK.

I alphabatized dicttoolz.

# unchanged: assoc_in and update_in 
typing them is hard, as you know

# other changes
- keys are bound to Hashable
- standardized TypeVar identifiers: only K and V or K0, K1 if more than one K
- factory Callable will eventually change from no input `[]` to indeterminate `...`. The code will take arguments, but the tests in `toolz` couldn't handle arguments, so there were not any tests for that. 

# challenges

I assumed the toolz and cytoolz codebases would be ..., uh, ... Well, most of the functions are far better than average, but other things, like tests and packaging and imports are mostly made of ducttape and prayers. So I've spent very little time on type annotations.

I think I've made some speed improvements to a few functions in toolz, but I've never learned how to do accurate benchmarks, so IDK how to figure out if I'm right.

One of my motivations for this project was to learn, and I am learning. But every minute I've worked on it has re-affirmed that I don't want to be a programmer. I left IT in 2005, and I still don't want to be doing this. So, I hope I'm able to give improvements to stubs and the code back to the original repos. If I recover, I don't want to maintain repos, but I also don't want to abandon anyone who is using the code. Right now, no one uses my repos, so that's not an issue. 

Uh, so help in the form of code or teaching me how to be a better developer would be appreciated.