### PR TITLE
remove the `typing_extensions` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 ]
 dependencies = [
   "toolz~=1.0",
-  "typing_extensions>=4.10; python_version < '3.13'"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
   "cytoolz~=1.0",
   "pytest>=8.4.2",
   "ruff>=0.14.1",
+  "typing_extensions>=4.10; python_version < '3.13'"
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -260,6 +260,7 @@ dev = [
     { name = "cytoolz" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 
 [package.metadata]
@@ -271,4 +272,14 @@ dev = [
     { name = "cytoolz", specifier = "~=1.0" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "ruff", specifier = ">=0.14.1" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.10" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -252,7 +252,6 @@ name = "toolz-stubs"
 source = { editable = "." }
 dependencies = [
     { name = "toolz" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 
 [package.dev-dependencies]
@@ -264,10 +263,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "toolz", specifier = "~=1.0" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.10" },
-]
+requires-dist = [{ name = "toolz", specifier = "~=1.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -275,13 +271,4 @@ dev = [
     { name = "cytoolz", specifier = "~=1.0" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "ruff", specifier = ">=0.14.1" },
-]
-
-[[package]]
-name = "typing-extensions"
-version = "4.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]


### PR DESCRIPTION
The typeshed `stdlib` stubs contain stubs for `typing_extensions` ([src](https://github.com/python/typeshed/blob/main/stdlib/typing_extensions.pyi)), which causes static type-checkers to think that `typing_extensions` is part of the Python standard libary. And because stubs are purely static, there's no need to have `typing_extensions` as a required dependency.