### PR TITLE
Improve typing for dicttoolz.get_in to enhance nested structure handling

### DIFF
--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -25,13 +25,15 @@ __all__ = (
 )
 
 @typing.overload
-def merge[K, V](*dicts: collections.abc.Mapping[K, V]) -> dict[K, V]: ...
+def merge[K: collections.abc.Hashable, V](
+    *dicts: collections.abc.Mapping[K, V],
+) -> dict[K, V]: ...
 @typing.overload
-def merge[K, V](
+def merge[K: collections.abc.Hashable, V](
     *dicts: collections.abc.Mapping[K, V],
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
-def merge[K, V](
+def merge[K: collections.abc.Hashable, V](
     *dicts: collections.abc.Mapping[K, V],
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
@@ -51,17 +53,17 @@ def merge[K, V](
     ...
 
 @typing.overload
-def merge_with[K, V](
+def merge_with[K: collections.abc.Hashable, V](
     func: collections.abc.Callable[[list[V]], V],
     *dicts: collections.abc.Mapping[K, V],
 ) -> dict[K, V]: ...
 @typing.overload
-def merge_with[K, V](
+def merge_with[K: collections.abc.Hashable, V](
     func: collections.abc.Callable[[list[V]], V],
     *dicts: collections.abc.Mapping[K, V],
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
-def merge_with[K, V](
+def merge_with[K: collections.abc.Hashable, V](
     func: collections.abc.Callable[[list[V]], V],
     *dicts: collections.abc.Mapping[K, V],
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
@@ -83,18 +85,18 @@ def merge_with[K, V](
     ...
 
 @typing.overload
-def valmap[K, V0, V1](
+def valmap[K: collections.abc.Hashable, V0, V1](
     func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
 ) -> dict[K, V1]: ...
 @typing.overload
-def valmap[K, V0, V1](
+def valmap[K: collections.abc.Hashable, V0, V1](
     func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
-def valmap[K, V0, V1](
+def valmap[K: collections.abc.Hashable, V0, V1](
     func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
     *,
@@ -113,18 +115,18 @@ def valmap[K, V0, V1](
     ...
 
 @typing.overload
-def keymap[K0, K1, V](
+def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
 ) -> dict[K1, V]: ...
 @typing.overload
-def keymap[K0, K1, V](
+def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
-def keymap[K0, K1, V](
+def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
     *,
@@ -143,18 +145,18 @@ def keymap[K0, K1, V](
     ...
 
 @typing.overload
-def itemmap[K0, V0, K1, V1](
+def itemmap[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: collections.abc.Mapping[K0, V0],
 ) -> dict[K1, V1]: ...
 @typing.overload
-def itemmap[K0, V0, K1, V1](
+def itemmap[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: collections.abc.Mapping[K0, V0],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
-def itemmap[K0, V0, K1, V1](
+def itemmap[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: collections.abc.Mapping[K0, V0],
     *,
@@ -175,42 +177,42 @@ def itemmap[K0, V0, K1, V1](
     ...
 
 @typing.overload
-def valfilter[K, V0, V1](
+def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], TypeIs[V1]],
     d: collections.abc.Mapping[K, V0],
 ) -> dict[K, V1]: ...
 @typing.overload
-def valfilter[K, V0, V1](
+def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], typing.TypeGuard[V1]],
     d: collections.abc.Mapping[K, V0],
 ) -> dict[K, V1]: ...
 @typing.overload
-def valfilter[K, V](
+def valfilter[K: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[V], bool],
     d: collections.abc.Mapping[K, V],
 ) -> dict[K, V]: ...
 @typing.overload
-def valfilter[K, V0, V1](
+def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], TypeIs[V1]],
     d: collections.abc.Mapping[K, V0],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 @typing.overload
-def valfilter[K, V0, V1](
+def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], typing.TypeGuard[V1]],
     d: collections.abc.Mapping[K, V0],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 @typing.overload
-def valfilter[K, V](
+def valfilter[K: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[V], bool],
     d: collections.abc.Mapping[K, V],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
-def valfilter[K, V0, V1](
+def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], bool]
     | collections.abc.Callable[[V0], typing.TypeGuard[V1]],
     d: collections.abc.Mapping[K, V0],
@@ -232,42 +234,42 @@ def valfilter[K, V0, V1](
     ...
 
 @typing.overload
-def keyfilter[K0, K1, V](
+def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], TypeIs[K1]],
     d: collections.abc.Mapping[K0, V],
 ) -> dict[K1, V]: ...
 @typing.overload
-def keyfilter[K0, K1, V](
+def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], typing.TypeGuard[K1]],
     d: collections.abc.Mapping[K0, V],
 ) -> dict[K1, V]: ...
 @typing.overload
-def keyfilter[K, V](
+def keyfilter[K: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K], bool],
     d: collections.abc.Mapping[K, V],
 ) -> dict[K, V]: ...
 @typing.overload
-def keyfilter[K0, K1, V](
+def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], TypeIs[K1]],
     d: collections.abc.Mapping[K0, V],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 @typing.overload
-def keyfilter[K0, K1, V](
+def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], typing.TypeGuard[K1]],
     d: collections.abc.Mapping[K0, V],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 @typing.overload
-def keyfilter[K, V](
+def keyfilter[K: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K], bool],
     d: collections.abc.Mapping[K, V],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
-def keyfilter[K0, K1, V](
+def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], bool]
     | collections.abc.Callable[[K0], typing.TypeGuard[K1]],
     d: collections.abc.Mapping[K0, V],
@@ -289,31 +291,31 @@ def keyfilter[K0, K1, V](
     ...
 
 @typing.overload
-def itemfilter[K0, K1, V0, V1](
+def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
     d: collections.abc.Mapping[K0, V0],
 ) -> dict[K1, V1]: ...
 @typing.overload
-def itemfilter[K0, K1, V0, V1](
+def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[
         [tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]
     ],
     d: collections.abc.Mapping[K0, V0],
 ) -> dict[K1, V1]: ...
 @typing.overload
-def itemfilter[K, V](
+def itemfilter[K: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[tuple[K, V]], bool],
     d: collections.abc.Mapping[K, V],
 ) -> dict[K, V]: ...
 @typing.overload
-def itemfilter[K0, K1, V0, V1](
+def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
     d: collections.abc.Mapping[K0, V0],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 @typing.overload
-def itemfilter[K0, K1, V0, V1](
+def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[
         [tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]
     ],
@@ -322,13 +324,13 @@ def itemfilter[K0, K1, V0, V1](
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 @typing.overload
-def itemfilter[K, V](
+def itemfilter[K: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[tuple[K, V]], bool],
     d: collections.abc.Mapping[K, V],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
-def itemfilter[K0, K1, V0, V1](
+def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[[tuple[K0, V0]], bool]
     | collections.abc.Callable[[tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]],
     d: collections.abc.Mapping[K0, V0],
@@ -355,20 +357,20 @@ def itemfilter[K0, K1, V0, V1](
     ...
 
 @typing.overload
-def assoc[K, V](
+def assoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     key: K,
     value: V,
 ) -> dict[K, V]: ...
 @typing.overload
-def assoc[K, V](
+def assoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     key: K,
     value: V,
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
-def assoc[K, V](
+def assoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     key: K,
     value: V,
@@ -387,17 +389,17 @@ def assoc[K, V](
     ...
 
 @typing.overload
-def dissoc[K, V](
+def dissoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     *keys: K,
 ) -> dict[K, V]: ...
 @typing.overload
-def dissoc[K, V](
+def dissoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     *keys: K,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
-def dissoc[K, V](
+def dissoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     *keys: K,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,

--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -214,7 +214,8 @@ def valfilter[K: collections.abc.Hashable, V0, V1](
 ) -> collections.abc.MutableMapping[K, V1]: ...
 def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], bool]
-    | collections.abc.Callable[[V0], typing.TypeGuard[V1]],
+    | collections.abc.Callable[[V0], typing.TypeGuard[V1]]
+    | collections.abc.Callable[[V0], TypeIs[V1]],
     d: collections.abc.Mapping[K, V0],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
@@ -271,7 +272,8 @@ def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
 ) -> collections.abc.MutableMapping[K1, V]: ...
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], bool]
-    | collections.abc.Callable[[K0], typing.TypeGuard[K1]],
+    | collections.abc.Callable[[K0], typing.TypeGuard[K1]]
+    | collections.abc.Callable[[K0], TypeIs[K1]],
     d: collections.abc.Mapping[K0, V],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
@@ -332,7 +334,8 @@ def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[[tuple[K0, V0]], bool]
-    | collections.abc.Callable[[tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]],
+    | collections.abc.Callable[[tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]]
+    | collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
     d: collections.abc.Mapping[K0, V0],
     *,
     factory: collections.abc.Callable[

--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -1,4 +1,3 @@
-# pyright: reportAny=false
 import collections.abc
 import sys
 import typing
@@ -565,33 +564,47 @@ def update_in[K, V](
     """
     ...
 
+_KT_contra = typing.TypeVar("_KT_contra", contravariant=True)
+_VT_co = typing.TypeVar("_VT_co", covariant=True)
+
+class _SupportsGetItem(typing.Protocol[_KT_contra, _VT_co]):
+    def __getitem__(self, key: _KT_contra, /) -> _VT_co: ...
+
+@typing.overload
+def get_in[K, V](
+    keys: collections.abc.Sequence[K],
+    coll: collections.abc.Sequence[V] | _SupportsGetItem[K, V],
+    default: None = None,
+    *,
+    no_default: typing.Literal[True],
+) -> V: ...
+@typing.overload
+def get_in[K, V](
+    keys: collections.abc.Sequence[K],
+    coll: collections.abc.Sequence[V] | _SupportsGetItem[K, V],
+    default: V,
+    no_default: typing.Literal[True],
+) -> V: ...
 @typing.overload
 def get_in[K, V0, V1](
-    keys: collections.abc.Iterable[K] | K,
-    coll: collections.abc.Iterable[V0] | collections.abc.Mapping[K, V0],
-    default: V0,
-    no_default: bool = ...,
-) -> V0: ...
-@typing.overload
-def get_in[K, V0, V1](
-    keys: collections.abc.Iterable[K] | K,
-    coll: collections.abc.Iterable[V0] | collections.abc.Mapping[K, V0],
-    default: V1 = ...,
-    no_default: bool = ...,
+    keys: collections.abc.Sequence[K],
+    coll: collections.abc.Sequence[V0] | _SupportsGetItem[K, V0],
+    default: V1,
+    no_default: bool = False,
 ) -> V0 | V1: ...
 @typing.overload
 def get_in[K, V](
-    keys: collections.abc.Iterable[K] | K,
-    coll: collections.abc.Iterable[V] | collections.abc.Mapping[K, V],
-    default: typing.Any = ...,
-    no_default: bool = ...,
-) -> typing.Any: ...
-def get_in[K, V](
-    keys: collections.abc.Iterable[K] | K,
-    coll: collections.abc.Iterable[V] | collections.abc.Mapping[K, V],
-    default: typing.Any = None,
+    keys: collections.abc.Sequence[K],
+    coll: collections.abc.Sequence[V] | _SupportsGetItem[K, V],
+    default: None = None,
     no_default: bool = False,
-) -> typing.Any:
+) -> V | None: ...
+def get_in[K, V0, V1](
+    keys: collections.abc.Sequence[K],
+    coll: collections.abc.Sequence[V0] | _SupportsGetItem[K, V0],
+    default: V1 | None = None,
+    no_default: bool = False,
+) -> V0 | V1 | None:
     """Returns coll[i0][i1]...[iX] where [i0, i1, ..., iX]==keys.
 
     If coll[i0][i1]...[iX] cannot be found, returns ``default``, unless

--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -54,17 +54,17 @@ def merge[K: collections.abc.Hashable, V](
 
 @typing.overload
 def merge_with[K: collections.abc.Hashable, V](
-    func: collections.abc.Callable[[list[V]], V],
+    func: collections.abc.Callable[[collections.abc.Sequence[V]], V],
     *dicts: collections.abc.Mapping[K, V],
 ) -> dict[K, V]: ...
 @typing.overload
 def merge_with[K: collections.abc.Hashable, V](
-    func: collections.abc.Callable[[list[V]], V],
+    func: collections.abc.Callable[[collections.abc.Sequence[V]], V],
     *dicts: collections.abc.Mapping[K, V],
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def merge_with[K: collections.abc.Hashable, V](
-    func: collections.abc.Callable[[list[V]], V],
+    func: collections.abc.Callable[[collections.abc.Sequence[V]], V],
     *dicts: collections.abc.Mapping[K, V],
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:

--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -213,9 +213,9 @@ def valfilter[K: collections.abc.Hashable, V0, V1](
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 def valfilter[K: collections.abc.Hashable, V0, V1](
-    predicate: collections.abc.Callable[[V0], bool]
+    predicate: collections.abc.Callable[[V0], TypeIs[V1]]
     | collections.abc.Callable[[V0], typing.TypeGuard[V1]]
-    | collections.abc.Callable[[V0], TypeIs[V1]],
+    | collections.abc.Callable[[V0], bool],
     d: collections.abc.Mapping[K, V0],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
@@ -271,9 +271,9 @@ def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
-    predicate: collections.abc.Callable[[K0], bool]
+    predicate: collections.abc.Callable[[K0], TypeIs[K1]]
     | collections.abc.Callable[[K0], typing.TypeGuard[K1]]
-    | collections.abc.Callable[[K0], TypeIs[K1]],
+    | collections.abc.Callable[[K0], bool],
     d: collections.abc.Mapping[K0, V],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
@@ -333,9 +333,9 @@ def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
-    predicate: collections.abc.Callable[[tuple[K0, V0]], bool]
+    predicate: collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]]
     | collections.abc.Callable[[tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]]
-    | collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
+    | collections.abc.Callable[[tuple[K0, V0]], bool],
     d: collections.abc.Mapping[K0, V0],
     *,
     factory: collections.abc.Callable[

--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -96,13 +96,11 @@ def valmap[K: collections.abc.Hashable, V0, V1](
 def valmap[K: collections.abc.Hashable, V0, V1](
     func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 def valmap[K: collections.abc.Hashable, V0, V1](
     func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
 ) -> collections.abc.MutableMapping[K, V1]:
     """Apply function to values of dictionary
@@ -127,13 +125,11 @@ def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
 def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
 ) -> collections.abc.MutableMapping[K1, V]:
     """Apply function to keys of dictionary
@@ -158,13 +154,11 @@ def itemmap[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
 def itemmap[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: collections.abc.Mapping[K0, V0],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 def itemmap[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: collections.abc.Mapping[K0, V0],
-    *,
     factory: collections.abc.Callable[
         [], collections.abc.MutableMapping[K1, V1]
     ] = dict,
@@ -202,21 +196,18 @@ def valfilter[K: collections.abc.Hashable, V](
 def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], TypeIs[V1]],
     d: collections.abc.Mapping[K, V0],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 @typing.overload
 def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], typing.TypeGuard[V1]],
     d: collections.abc.Mapping[K, V0],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 @typing.overload
 def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], bool],
     d: collections.abc.Mapping[K, V0],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 def valfilter[K: collections.abc.Hashable, V0, V1](
@@ -224,7 +215,6 @@ def valfilter[K: collections.abc.Hashable, V0, V1](
     | collections.abc.Callable[[V0], typing.TypeGuard[V1]]
     | collections.abc.Callable[[V0], bool],
     d: collections.abc.Mapping[K, V0],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
 ) -> collections.abc.MutableMapping[K, V1]:
     """Filter items in dictionary by value
@@ -263,21 +253,18 @@ def keyfilter[K: collections.abc.Hashable, V](
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], TypeIs[K1]],
     d: collections.abc.Mapping[K0, V],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 @typing.overload
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], typing.TypeGuard[K1]],
     d: collections.abc.Mapping[K0, V],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 @typing.overload
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], bool],
     d: collections.abc.Mapping[K0, V],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
@@ -285,7 +272,6 @@ def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     | collections.abc.Callable[[K0], typing.TypeGuard[K1]]
     | collections.abc.Callable[[K0], bool],
     d: collections.abc.Mapping[K0, V],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
 ) -> collections.abc.MutableMapping[K1, V]:
     """Filter items in dictionary by key
@@ -326,7 +312,6 @@ def itemfilter[K: collections.abc.Hashable, V](
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
     d: collections.abc.Mapping[K0, V0],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 @typing.overload
@@ -335,14 +320,12 @@ def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V
         [tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]
     ],
     d: collections.abc.Mapping[K0, V0],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 @typing.overload
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[[tuple[K0, V0]], bool],
     d: collections.abc.Mapping[K0, V0],
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
@@ -350,7 +333,6 @@ def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V
     | collections.abc.Callable[[tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]]
     | collections.abc.Callable[[tuple[K0, V0]], bool],
     d: collections.abc.Mapping[K0, V0],
-    *,
     factory: collections.abc.Callable[
         [], collections.abc.MutableMapping[K1, V1]
     ] = dict,
@@ -384,14 +366,12 @@ def assoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     key: K,
     value: V,
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def assoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     key: K,
     value: V,
-    *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Return a new dict with new key value pair

--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -175,34 +175,34 @@ def itemmap[K0, V0, K1, V1](
     ...
 
 @typing.overload
-def valfilter[K, V, R](
-    predicate: collections.abc.Callable[[V], TypeIs[R]],
-    d: collections.abc.Mapping[K, V],
-) -> dict[K, R]: ...
+def valfilter[K, V0, V1](
+    predicate: collections.abc.Callable[[V0], TypeIs[V1]],
+    d: collections.abc.Mapping[K, V0],
+) -> dict[K, V1]: ...
 @typing.overload
-def valfilter[K, V, R](
-    predicate: collections.abc.Callable[[V], typing.TypeGuard[R]],
-    d: collections.abc.Mapping[K, V],
-) -> dict[K, R]: ...
+def valfilter[K, V0, V1](
+    predicate: collections.abc.Callable[[V0], typing.TypeGuard[V1]],
+    d: collections.abc.Mapping[K, V0],
+) -> dict[K, V1]: ...
 @typing.overload
 def valfilter[K, V](
     predicate: collections.abc.Callable[[V], bool],
     d: collections.abc.Mapping[K, V],
 ) -> dict[K, V]: ...
 @typing.overload
-def valfilter[K, V, R](
-    predicate: collections.abc.Callable[[V], TypeIs[R]],
-    d: collections.abc.Mapping[K, V],
+def valfilter[K, V0, V1](
+    predicate: collections.abc.Callable[[V0], TypeIs[V1]],
+    d: collections.abc.Mapping[K, V0],
     *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, R]],
-) -> collections.abc.MutableMapping[K, R]: ...
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
+) -> collections.abc.MutableMapping[K, V1]: ...
 @typing.overload
-def valfilter[K, V, R](
-    predicate: collections.abc.Callable[[V], typing.TypeGuard[R]],
-    d: collections.abc.Mapping[K, V],
+def valfilter[K, V0, V1](
+    predicate: collections.abc.Callable[[V0], typing.TypeGuard[V1]],
+    d: collections.abc.Mapping[K, V0],
     *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, R]],
-) -> collections.abc.MutableMapping[K, R]: ...
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
+) -> collections.abc.MutableMapping[K, V1]: ...
 @typing.overload
 def valfilter[K, V](
     predicate: collections.abc.Callable[[V], bool],
@@ -210,13 +210,13 @@ def valfilter[K, V](
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
-def valfilter[K, V, R](
-    predicate: collections.abc.Callable[[V], bool]
-    | collections.abc.Callable[[V], typing.TypeGuard[R]],
-    d: collections.abc.Mapping[K, V],
+def valfilter[K, V0, V1](
+    predicate: collections.abc.Callable[[V0], bool]
+    | collections.abc.Callable[[V0], typing.TypeGuard[V1]],
+    d: collections.abc.Mapping[K, V0],
     *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
-) -> collections.abc.MutableMapping[K, V]:
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V0]] = dict,
+) -> collections.abc.MutableMapping[K, V0]:
     """Filter items in dictionary by value
 
     >>> iseven = lambda x: x % 2 == 0
@@ -232,34 +232,34 @@ def valfilter[K, V, R](
     ...
 
 @typing.overload
-def keyfilter[K, V, R](
-    predicate: collections.abc.Callable[[K], TypeIs[R]],
-    d: collections.abc.Mapping[K, V],
-) -> dict[R, V]: ...
+def keyfilter[K0, K1, V](
+    predicate: collections.abc.Callable[[K0], TypeIs[K1]],
+    d: collections.abc.Mapping[K0, V],
+) -> dict[K1, V]: ...
 @typing.overload
-def keyfilter[K, V, R](
-    predicate: collections.abc.Callable[[K], typing.TypeGuard[R]],
-    d: collections.abc.Mapping[K, V],
-) -> dict[R, V]: ...
+def keyfilter[K0, K1, V](
+    predicate: collections.abc.Callable[[K0], typing.TypeGuard[K1]],
+    d: collections.abc.Mapping[K0, V],
+) -> dict[K1, V]: ...
 @typing.overload
 def keyfilter[K, V](
     predicate: collections.abc.Callable[[K], bool],
     d: collections.abc.Mapping[K, V],
 ) -> dict[K, V]: ...
 @typing.overload
-def keyfilter[K, V, R](
-    predicate: collections.abc.Callable[[K], TypeIs[R]],
-    d: collections.abc.Mapping[K, V],
+def keyfilter[K0, K1, V](
+    predicate: collections.abc.Callable[[K0], TypeIs[K1]],
+    d: collections.abc.Mapping[K0, V],
     *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[R, V]],
-) -> collections.abc.MutableMapping[R, V]: ...
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
+) -> collections.abc.MutableMapping[K1, V]: ...
 @typing.overload
-def keyfilter[K, V, R](
-    predicate: collections.abc.Callable[[K], typing.TypeGuard[R]],
-    d: collections.abc.Mapping[K, V],
+def keyfilter[K0, K1, V](
+    predicate: collections.abc.Callable[[K0], typing.TypeGuard[K1]],
+    d: collections.abc.Mapping[K0, V],
     *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[R, V]],
-) -> collections.abc.MutableMapping[R, V]: ...
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
+) -> collections.abc.MutableMapping[K1, V]: ...
 @typing.overload
 def keyfilter[K, V](
     predicate: collections.abc.Callable[[K], bool],
@@ -267,13 +267,13 @@ def keyfilter[K, V](
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
-def keyfilter[K, V, R](
-    predicate: collections.abc.Callable[[K], bool]
-    | collections.abc.Callable[[K], typing.TypeGuard[R]],
-    d: collections.abc.Mapping[K, V],
+def keyfilter[K0, K1, V](
+    predicate: collections.abc.Callable[[K0], bool]
+    | collections.abc.Callable[[K0], typing.TypeGuard[K1]],
+    d: collections.abc.Mapping[K0, V],
     *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
-) -> collections.abc.MutableMapping[K, V]:
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
+) -> collections.abc.MutableMapping[K1, V]:
     """Filter items in dictionary by key
 
     >>> iseven = lambda x: x % 2 == 0
@@ -289,14 +289,16 @@ def keyfilter[K, V, R](
     ...
 
 @typing.overload
-def itemfilter[K, V, K1, V1](
-    predicate: collections.abc.Callable[[tuple[K, V]], TypeIs[tuple[K1, V1]]],
-    d: collections.abc.Mapping[K, V],
+def itemfilter[K0, K1, V0, V1](
+    predicate: collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
+    d: collections.abc.Mapping[K0, V0],
 ) -> dict[K1, V1]: ...
 @typing.overload
-def itemfilter[K, V, K1, V1](
-    predicate: collections.abc.Callable[[tuple[K, V]], typing.TypeGuard[tuple[K1, V1]]],
-    d: collections.abc.Mapping[K, V],
+def itemfilter[K0, K1, V0, V1](
+    predicate: collections.abc.Callable[
+        [tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]
+    ],
+    d: collections.abc.Mapping[K0, V0],
 ) -> dict[K1, V1]: ...
 @typing.overload
 def itemfilter[K, V](
@@ -304,16 +306,18 @@ def itemfilter[K, V](
     d: collections.abc.Mapping[K, V],
 ) -> dict[K, V]: ...
 @typing.overload
-def itemfilter[K, V, K1, V1](
-    predicate: collections.abc.Callable[[tuple[K, V]], TypeIs[tuple[K1, V1]]],
-    d: collections.abc.Mapping[K, V],
+def itemfilter[K0, K1, V0, V1](
+    predicate: collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
+    d: collections.abc.Mapping[K0, V0],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 @typing.overload
-def itemfilter[K, V, K1, V1](
-    predicate: collections.abc.Callable[[tuple[K, V]], typing.TypeGuard[tuple[K1, V1]]],
-    d: collections.abc.Mapping[K, V],
+def itemfilter[K0, K1, V0, V1](
+    predicate: collections.abc.Callable[
+        [tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]
+    ],
+    d: collections.abc.Mapping[K0, V0],
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
@@ -324,13 +328,15 @@ def itemfilter[K, V](
     *,
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
-def itemfilter[K, V, K1, V1](
-    predicate: collections.abc.Callable[[tuple[K, V]], bool]
-    | collections.abc.Callable[[tuple[K, V]], typing.TypeGuard[tuple[K1, V1]]],
-    d: collections.abc.Mapping[K, V],
+def itemfilter[K0, K1, V0, V1](
+    predicate: collections.abc.Callable[[tuple[K0, V0]], bool]
+    | collections.abc.Callable[[tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]],
+    d: collections.abc.Mapping[K0, V0],
     *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
-) -> collections.abc.MutableMapping[K, V]:
+    factory: collections.abc.Callable[
+        [], collections.abc.MutableMapping[K0, V0]
+    ] = dict,
+) -> collections.abc.MutableMapping[K0, V0]:
     """Filter items in dictionary by item
 
     >>> def isvalid(item):
@@ -551,19 +557,19 @@ def update_in[K, V](
     ...
 
 @typing.overload
-def get_in[K, V, D](
+def get_in[K, V0, V1](
     keys: collections.abc.Iterable[K] | K,
-    coll: collections.abc.Iterable[V] | collections.abc.Mapping[K, V],
-    default: V,
+    coll: collections.abc.Iterable[V0] | collections.abc.Mapping[K, V0],
+    default: V0,
     no_default: bool = ...,
-) -> V: ...
+) -> V0: ...
 @typing.overload
-def get_in[K, V, D](
+def get_in[K, V0, V1](
     keys: collections.abc.Iterable[K] | K,
-    coll: collections.abc.Iterable[V] | collections.abc.Mapping[K, V],
-    default: D = ...,
+    coll: collections.abc.Iterable[V0] | collections.abc.Mapping[K, V0],
+    default: V1 = ...,
     no_default: bool = ...,
-) -> V | D: ...
+) -> V0 | V1: ...
 @typing.overload
 def get_in[K, V](
     keys: collections.abc.Iterable[K] | K,

--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -27,6 +27,7 @@ __all__ = (
 @typing.overload
 def merge[K: collections.abc.Hashable, V](
     *dicts: collections.abc.Mapping[K, V],
+    factory: collections.abc.Callable[[], dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @typing.overload
 def merge[K: collections.abc.Hashable, V](
@@ -56,6 +57,7 @@ def merge[K: collections.abc.Hashable, V](
 def merge_with[K: collections.abc.Hashable, V](
     func: collections.abc.Callable[[collections.abc.Sequence[V]], V],
     *dicts: collections.abc.Mapping[K, V],
+    factory: collections.abc.Callable[[], dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @typing.overload
 def merge_with[K: collections.abc.Hashable, V](
@@ -88,6 +90,7 @@ def merge_with[K: collections.abc.Hashable, V](
 def valmap[K: collections.abc.Hashable, V0, V1](
     func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
+    factory: collections.abc.Callable[[], dict[K, V1]] = dict,
 ) -> dict[K, V1]: ...
 @typing.overload
 def valmap[K: collections.abc.Hashable, V0, V1](
@@ -118,6 +121,7 @@ def valmap[K: collections.abc.Hashable, V0, V1](
 def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
+    factory: collections.abc.Callable[[], dict[K1, V]] = dict,
 ) -> dict[K1, V]: ...
 @typing.overload
 def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
@@ -148,6 +152,7 @@ def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
 def itemmap[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: collections.abc.Mapping[K0, V0],
+    factory: collections.abc.Callable[..., dict[K1, V1]] = dict,
 ) -> dict[K1, V1]: ...
 @typing.overload
 def itemmap[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
@@ -180,11 +185,13 @@ def itemmap[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
 def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], TypeIs[V1]],
     d: collections.abc.Mapping[K, V0],
+    factory: collections.abc.Callable[[], dict[K, V1]] = dict,
 ) -> dict[K, V1]: ...
 @typing.overload
 def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], typing.TypeGuard[V1]],
     d: collections.abc.Mapping[K, V0],
+    factory: collections.abc.Callable[[], dict[K, V1]] = dict,
 ) -> dict[K, V1]: ...
 @typing.overload
 def valfilter[K: collections.abc.Hashable, V](
@@ -238,16 +245,19 @@ def valfilter[K: collections.abc.Hashable, V0, V1](
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], TypeIs[K1]],
     d: collections.abc.Mapping[K0, V],
+    factory: collections.abc.Callable[[], dict[K1, V]] = dict,
 ) -> dict[K1, V]: ...
 @typing.overload
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], typing.TypeGuard[K1]],
     d: collections.abc.Mapping[K0, V],
+    factory: collections.abc.Callable[[], dict[K1, V]] = dict,
 ) -> dict[K1, V]: ...
 @typing.overload
 def keyfilter[K: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K], bool],
     d: collections.abc.Mapping[K, V],
+    factory: collections.abc.Callable[[], dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @typing.overload
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
@@ -296,6 +306,7 @@ def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
     d: collections.abc.Mapping[K0, V0],
+    factory: collections.abc.Callable[[], dict[K1, V1]] = dict,
 ) -> dict[K1, V1]: ...
 @typing.overload
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
@@ -303,11 +314,13 @@ def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V
         [tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]
     ],
     d: collections.abc.Mapping[K0, V0],
+    factory: collections.abc.Callable[[], dict[K1, V1]] = dict,
 ) -> dict[K1, V1]: ...
 @typing.overload
 def itemfilter[K: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[tuple[K, V]], bool],
     d: collections.abc.Mapping[K, V],
+    factory: collections.abc.Callable[[], dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @typing.overload
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
@@ -364,6 +377,7 @@ def assoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     key: K,
     value: V,
+    factory: collections.abc.Callable[[], dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @typing.overload
 def assoc[K: collections.abc.Hashable, V](
@@ -395,6 +409,7 @@ def assoc[K: collections.abc.Hashable, V](
 def dissoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     *keys: K,
+    factory: collections.abc.Callable[[], dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @typing.overload
 def dissoc[K: collections.abc.Hashable, V](

--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -191,6 +191,7 @@ def valfilter[K: collections.abc.Hashable, V0, V1](
 def valfilter[K: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[V], bool],
     d: collections.abc.Mapping[K, V],
+    factory: collections.abc.Callable[..., dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @typing.overload
 def valfilter[K: collections.abc.Hashable, V0, V1](

--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -27,16 +27,16 @@ __all__ = (
 @typing.overload
 def merge[K: collections.abc.Hashable, V](
     *dicts: collections.abc.Mapping[K, V],
-    factory: collections.abc.Callable[[], dict[K, V]] = dict,
+    factory: collections.abc.Callable[..., dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @typing.overload
 def merge[K: collections.abc.Hashable, V](
     *dicts: collections.abc.Mapping[K, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def merge[K: collections.abc.Hashable, V](
     *dicts: collections.abc.Mapping[K, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Merge a collection of dictionaries
 
@@ -57,18 +57,18 @@ def merge[K: collections.abc.Hashable, V](
 def merge_with[K: collections.abc.Hashable, V](
     func: collections.abc.Callable[[collections.abc.Sequence[V]], V],
     *dicts: collections.abc.Mapping[K, V],
-    factory: collections.abc.Callable[[], dict[K, V]] = dict,
+    factory: collections.abc.Callable[..., dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @typing.overload
 def merge_with[K: collections.abc.Hashable, V](
     func: collections.abc.Callable[[collections.abc.Sequence[V]], V],
     *dicts: collections.abc.Mapping[K, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def merge_with[K: collections.abc.Hashable, V](
     func: collections.abc.Callable[[collections.abc.Sequence[V]], V],
     *dicts: collections.abc.Mapping[K, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Merge dictionaries and apply function to combined values
 
@@ -90,18 +90,20 @@ def merge_with[K: collections.abc.Hashable, V](
 def valmap[K: collections.abc.Hashable, V0, V1](
     func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
-    factory: collections.abc.Callable[[], dict[K, V1]] = dict,
+    factory: collections.abc.Callable[..., dict[K, V1]] = dict,
 ) -> dict[K, V1]: ...
 @typing.overload
 def valmap[K: collections.abc.Hashable, V0, V1](
     func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 def valmap[K: collections.abc.Hashable, V0, V1](
     func: collections.abc.Callable[[V0], V1],
     d: collections.abc.Mapping[K, V0],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
+    factory: collections.abc.Callable[
+        ..., collections.abc.MutableMapping[K, V1]
+    ] = dict,
 ) -> collections.abc.MutableMapping[K, V1]:
     """Apply function to values of dictionary
 
@@ -119,18 +121,20 @@ def valmap[K: collections.abc.Hashable, V0, V1](
 def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
-    factory: collections.abc.Callable[[], dict[K1, V]] = dict,
+    factory: collections.abc.Callable[..., dict[K1, V]] = dict,
 ) -> dict[K1, V]: ...
 @typing.overload
 def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 def keymap[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     func: collections.abc.Callable[[K0], K1],
     d: collections.abc.Mapping[K0, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
+    factory: collections.abc.Callable[
+        ..., collections.abc.MutableMapping[K1, V]
+    ] = dict,
 ) -> collections.abc.MutableMapping[K1, V]:
     """Apply function to keys of dictionary
 
@@ -154,13 +158,13 @@ def itemmap[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
 def itemmap[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: collections.abc.Mapping[K0, V0],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 def itemmap[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     func: collections.abc.Callable[[tuple[K0, V0]], tuple[K1, V1]],
     d: collections.abc.Mapping[K0, V0],
     factory: collections.abc.Callable[
-        [], collections.abc.MutableMapping[K1, V1]
+        ..., collections.abc.MutableMapping[K1, V1]
     ] = dict,
 ) -> collections.abc.MutableMapping[K1, V1]:
     """Apply function to items of dictionary
@@ -179,13 +183,13 @@ def itemmap[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
 def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], TypeIs[V1]],
     d: collections.abc.Mapping[K, V0],
-    factory: collections.abc.Callable[[], dict[K, V1]] = dict,
+    factory: collections.abc.Callable[..., dict[K, V1]] = dict,
 ) -> dict[K, V1]: ...
 @typing.overload
 def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], typing.TypeGuard[V1]],
     d: collections.abc.Mapping[K, V0],
-    factory: collections.abc.Callable[[], dict[K, V1]] = dict,
+    factory: collections.abc.Callable[..., dict[K, V1]] = dict,
 ) -> dict[K, V1]: ...
 @typing.overload
 def valfilter[K: collections.abc.Hashable, V](
@@ -197,26 +201,28 @@ def valfilter[K: collections.abc.Hashable, V](
 def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], TypeIs[V1]],
     d: collections.abc.Mapping[K, V0],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 @typing.overload
 def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], typing.TypeGuard[V1]],
     d: collections.abc.Mapping[K, V0],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 @typing.overload
 def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], bool],
     d: collections.abc.Mapping[K, V0],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], TypeIs[V1]]
     | collections.abc.Callable[[V0], typing.TypeGuard[V1]]
     | collections.abc.Callable[[V0], bool],
     d: collections.abc.Mapping[K, V0],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
+    factory: collections.abc.Callable[
+        ..., collections.abc.MutableMapping[K, V1]
+    ] = dict,
 ) -> collections.abc.MutableMapping[K, V1]:
     """Filter items in dictionary by value
 
@@ -236,44 +242,46 @@ def valfilter[K: collections.abc.Hashable, V0, V1](
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], TypeIs[K1]],
     d: collections.abc.Mapping[K0, V],
-    factory: collections.abc.Callable[[], dict[K1, V]] = dict,
+    factory: collections.abc.Callable[..., dict[K1, V]] = dict,
 ) -> dict[K1, V]: ...
 @typing.overload
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], typing.TypeGuard[K1]],
     d: collections.abc.Mapping[K0, V],
-    factory: collections.abc.Callable[[], dict[K1, V]] = dict,
+    factory: collections.abc.Callable[..., dict[K1, V]] = dict,
 ) -> dict[K1, V]: ...
 @typing.overload
 def keyfilter[K: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K], bool],
     d: collections.abc.Mapping[K, V],
-    factory: collections.abc.Callable[[], dict[K, V]] = dict,
+    factory: collections.abc.Callable[..., dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @typing.overload
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], TypeIs[K1]],
     d: collections.abc.Mapping[K0, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 @typing.overload
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], typing.TypeGuard[K1]],
     d: collections.abc.Mapping[K0, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 @typing.overload
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], bool],
     d: collections.abc.Mapping[K0, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], TypeIs[K1]]
     | collections.abc.Callable[[K0], typing.TypeGuard[K1]]
     | collections.abc.Callable[[K0], bool],
     d: collections.abc.Mapping[K0, V],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]] = dict,
+    factory: collections.abc.Callable[
+        ..., collections.abc.MutableMapping[K1, V]
+    ] = dict,
 ) -> collections.abc.MutableMapping[K1, V]:
     """Filter items in dictionary by key
 
@@ -293,7 +301,7 @@ def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
     d: collections.abc.Mapping[K0, V0],
-    factory: collections.abc.Callable[[], dict[K1, V1]] = dict,
+    factory: collections.abc.Callable[..., dict[K1, V1]] = dict,
 ) -> dict[K1, V1]: ...
 @typing.overload
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
@@ -301,19 +309,19 @@ def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V
         [tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]
     ],
     d: collections.abc.Mapping[K0, V0],
-    factory: collections.abc.Callable[[], dict[K1, V1]] = dict,
+    factory: collections.abc.Callable[..., dict[K1, V1]] = dict,
 ) -> dict[K1, V1]: ...
 @typing.overload
 def itemfilter[K: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[tuple[K, V]], bool],
     d: collections.abc.Mapping[K, V],
-    factory: collections.abc.Callable[[], dict[K, V]] = dict,
+    factory: collections.abc.Callable[..., dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @typing.overload
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]],
     d: collections.abc.Mapping[K0, V0],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 @typing.overload
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
@@ -321,13 +329,13 @@ def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V
         [tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]
     ],
     d: collections.abc.Mapping[K0, V0],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 @typing.overload
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[[tuple[K0, V0]], bool],
     d: collections.abc.Mapping[K0, V0],
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[[tuple[K0, V0]], TypeIs[tuple[K1, V1]]]
@@ -335,7 +343,7 @@ def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V
     | collections.abc.Callable[[tuple[K0, V0]], bool],
     d: collections.abc.Mapping[K0, V0],
     factory: collections.abc.Callable[
-        [], collections.abc.MutableMapping[K1, V1]
+        ..., collections.abc.MutableMapping[K1, V1]
     ] = dict,
 ) -> collections.abc.MutableMapping[K1, V1]:
     """Filter items in dictionary by item
@@ -360,20 +368,20 @@ def assoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     key: K,
     value: V,
-    factory: collections.abc.Callable[[], dict[K, V]] = dict,
+    factory: collections.abc.Callable[..., dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @typing.overload
 def assoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     key: K,
     value: V,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def assoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     key: K,
     value: V,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Return a new dict with new key value pair
 
@@ -390,18 +398,18 @@ def assoc[K: collections.abc.Hashable, V](
 def dissoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     *keys: K,
-    factory: collections.abc.Callable[[], dict[K, V]] = dict,
+    factory: collections.abc.Callable[..., dict[K, V]] = dict,
 ) -> dict[K, V]: ...
 @typing.overload
 def dissoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     *keys: K,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def dissoc[K: collections.abc.Hashable, V](
     d: collections.abc.Mapping[K, V],
     *keys: K,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Return a new dict with the given key(s) removed.
 
@@ -431,7 +439,7 @@ def assoc_in[K1, K2, V1, V2](
     value: V2,
     *,
     factory: collections.abc.Callable[
-        [], collections.abc.MutableMapping[K1, typing.Any]
+        ..., collections.abc.MutableMapping[K1, typing.Any]
     ],
 ) -> collections.abc.MutableMapping[K1, typing.Any]: ...
 
@@ -453,7 +461,7 @@ def assoc_in[K1, K2, K3, V1, V2, V3](
     value: V3,
     *,
     factory: collections.abc.Callable[
-        [], collections.abc.MutableMapping[K1, typing.Any]
+        ..., collections.abc.MutableMapping[K1, typing.Any]
     ],
 ) -> collections.abc.MutableMapping[K1, typing.Any]: ...
 
@@ -470,14 +478,14 @@ def assoc_in[K, V](
     keys: collections.abc.Iterable[K] | K,
     value: V,
     *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 def assoc_in[K, V](
     d: collections.abc.Mapping[K, V],
     keys: collections.abc.Iterable[K] | K,
     value: V,
     *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Return a new dict with new, potentially nested, key value pair
 
@@ -505,7 +513,7 @@ def update_in[K, V](
     keys: collections.abc.Iterable[K] | K,
     func: collections.abc.Callable[..., V],
     default: typing.Any | None,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V]],
 ) -> collections.abc.MutableMapping[K, V]: ...
 @typing.overload
 def update_in[K, V](
@@ -513,14 +521,14 @@ def update_in[K, V](
     keys: collections.abc.Iterable[K] | K,
     func: collections.abc.Callable[..., V],
     default: typing.Any | None = None,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]: ...
 def update_in[K, V](
     d: collections.abc.Mapping[K, V],
     keys: collections.abc.Iterable[K] | K,
     func: collections.abc.Callable[..., V],
     default: typing.Any | None = None,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]] = dict,
+    factory: collections.abc.Callable[..., collections.abc.MutableMapping[K, V]] = dict,
 ) -> collections.abc.MutableMapping[K, V]:
     """Update value in a (potentially) nested dictionary
 

--- a/src/toolz-stubs/dicttoolz.pyi
+++ b/src/toolz-stubs/dicttoolz.pyi
@@ -206,19 +206,19 @@ def valfilter[K: collections.abc.Hashable, V0, V1](
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
 ) -> collections.abc.MutableMapping[K, V1]: ...
 @typing.overload
-def valfilter[K: collections.abc.Hashable, V](
-    predicate: collections.abc.Callable[[V], bool],
-    d: collections.abc.Mapping[K, V],
+def valfilter[K: collections.abc.Hashable, V0, V1](
+    predicate: collections.abc.Callable[[V0], bool],
+    d: collections.abc.Mapping[K, V0],
     *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> collections.abc.MutableMapping[K, V]: ...
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]],
+) -> collections.abc.MutableMapping[K, V1]: ...
 def valfilter[K: collections.abc.Hashable, V0, V1](
     predicate: collections.abc.Callable[[V0], bool]
     | collections.abc.Callable[[V0], typing.TypeGuard[V1]],
     d: collections.abc.Mapping[K, V0],
     *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V0]] = dict,
-) -> collections.abc.MutableMapping[K, V0]:
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V1]] = dict,
+) -> collections.abc.MutableMapping[K, V1]:
     """Filter items in dictionary by value
 
     >>> iseven = lambda x: x % 2 == 0
@@ -263,12 +263,12 @@ def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
 ) -> collections.abc.MutableMapping[K1, V]: ...
 @typing.overload
-def keyfilter[K: collections.abc.Hashable, V](
-    predicate: collections.abc.Callable[[K], bool],
-    d: collections.abc.Mapping[K, V],
+def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
+    predicate: collections.abc.Callable[[K0], bool],
+    d: collections.abc.Mapping[K0, V],
     *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> collections.abc.MutableMapping[K, V]: ...
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V]],
+) -> collections.abc.MutableMapping[K1, V]: ...
 def keyfilter[K0: collections.abc.Hashable, K1: collections.abc.Hashable, V](
     predicate: collections.abc.Callable[[K0], bool]
     | collections.abc.Callable[[K0], typing.TypeGuard[K1]],
@@ -324,21 +324,21 @@ def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V
     factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
 ) -> collections.abc.MutableMapping[K1, V1]: ...
 @typing.overload
-def itemfilter[K: collections.abc.Hashable, V](
-    predicate: collections.abc.Callable[[tuple[K, V]], bool],
-    d: collections.abc.Mapping[K, V],
+def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
+    predicate: collections.abc.Callable[[tuple[K0, V0]], bool],
+    d: collections.abc.Mapping[K0, V0],
     *,
-    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K, V]],
-) -> collections.abc.MutableMapping[K, V]: ...
+    factory: collections.abc.Callable[[], collections.abc.MutableMapping[K1, V1]],
+) -> collections.abc.MutableMapping[K1, V1]: ...
 def itemfilter[K0: collections.abc.Hashable, V0, K1: collections.abc.Hashable, V1](
     predicate: collections.abc.Callable[[tuple[K0, V0]], bool]
     | collections.abc.Callable[[tuple[K0, V0]], typing.TypeGuard[tuple[K1, V1]]],
     d: collections.abc.Mapping[K0, V0],
     *,
     factory: collections.abc.Callable[
-        [], collections.abc.MutableMapping[K0, V0]
+        [], collections.abc.MutableMapping[K1, V1]
     ] = dict,
-) -> collections.abc.MutableMapping[K0, V0]:
+) -> collections.abc.MutableMapping[K1, V1]:
     """Filter items in dictionary by item
 
     >>> def isvalid(item):

--- a/tests/test_dicttoolz.py
+++ b/tests/test_dicttoolz.py
@@ -138,7 +138,11 @@ class TestKeyfilter:
 
     def test_string_values(self) -> None:
         """keyfilter with string values (README example)."""
-        result = dt.keyfilter(lambda k: k % 2 == 0, {1: "a", 2: "b", 3: "c"})
+
+        def iseven(x: int) -> bool:
+            return x % 2 == 0
+
+        result = dt.keyfilter(iseven, {1: "a", 2: "b", 3: "c"})
 
         _ = assert_type(result, dict[int, str])
         assert result == {2: "b"}

--- a/tests/test_dicttoolz.py
+++ b/tests/test_dicttoolz.py
@@ -376,29 +376,29 @@ class TestGetIn:
     #     _ = assert_type(result, str | dict[str, list[str] | list[float]] | None)
     #     assert result == "Apple"
 
-    # def test_single_key(self) -> None:
-    #     """get_in with single key."""
-    #     transaction = {
-    #         "name": "Alice",
-    #         "purchase": {"items": ["Apple", "Orange"], "costs": [0.50, 1.25]},
-    #         "credit card": "5555-1234-1234-1234",
-    #     }
-    #     result = dt.get_in(["name"], transaction)
+    def test_single_key(self) -> None:
+        """get_in with single key."""
+        transaction = {
+            "name": "Alice",
+            "purchase": {"items": ["Apple", "Orange"], "costs": [0.50, 1.25]},
+            "credit card": "5555-1234-1234-1234",
+        }
+        result = dt.get_in(["name"], transaction)
 
-    #     _ = assert_type(result, str | dict[str, list[str] | list[float]] | None)
-    #     assert result == "Alice"
+        _ = assert_type(result, str | dict[str, list[str] | list[float]] | None)
+        assert result == "Alice"
 
-    # def test_missing_returns_none(self) -> None:
-    #     """get_in returns None for missing key by default."""
-    #     transaction = {
-    #         "name": "Alice",
-    #         "purchase": {"items": ["Apple", "Orange"], "costs": [0.50, 1.25]},
-    #         "credit card": "5555-1234-1234-1234",
-    #     }
-    #     result = dt.get_in(["purchase", "total"], transaction)
+    def test_missing_returns_none(self) -> None:
+        """get_in returns None for missing key by default."""
+        transaction = {
+            "name": "Alice",
+            "purchase": {"items": ["Apple", "Orange"], "costs": [0.50, 1.25]},
+            "credit card": "5555-1234-1234-1234",
+        }
+        result = dt.get_in(["purchase", "total"], transaction)
 
-    #     _ = assert_type(result, str | dict[str, list[str] | list[float]] | None)
-    #     assert result is None
+        _ = assert_type(result, str | dict[str, list[str] | list[float]] | None)
+        assert result is None
 
     # def test_missing_index_returns_none(self) -> None:
     #     """get_in returns None for missing index."""
@@ -412,20 +412,22 @@ class TestGetIn:
     #     _ = assert_type(result, str | dict[str, list[str] | list[float]] | None)
     #     assert result is None
 
-    # def test_with_default(self) -> None:
-    #     """get_in with explicit default value."""
-    #     transaction = {
-    #         "name": "Alice",
-    #         "purchase": {"items": ["Apple", "Orange"], "costs": [0.50, 1.25]},
-    #         "credit card": "5555-1234-1234-1234",
-    #     }
-    #     result = dt.get_in(["purchase", "total"], transaction, 0)
+    def test_with_default(self) -> None:
+        """get_in with explicit default value."""
+        transaction = {
+            "name": "Alice",
+            "purchase": {"items": ["Apple", "Orange"], "costs": [0.50, 1.25]},
+            "credit card": "5555-1234-1234-1234",
+        }
+        result = dt.get_in(["purchase", "total"], transaction, 0)
 
-    #     _ = assert_type(result, str | dict[str, list[str] | list[float]] | int)
-    #     assert result == 0
+        _ = assert_type(result, str | dict[str, list[str] | list[float]] | int)
+        assert result == 0
 
     def test_no_default_raises(self) -> None:
         """get_in with no_default=True should raise KeyError."""
 
+        coll: dict[str, int] = {}
+
         with pytest.raises(KeyError):
-            _ = dt.get_in(["y"], {}, no_default=True)
+            _ = dt.get_in(["y"], coll, no_default=True)

--- a/tests/test_tlz_dicttoolz.py
+++ b/tests/test_tlz_dicttoolz.py
@@ -86,7 +86,10 @@ def test_valfilter() -> None:
     """valfilter should filter by value."""
     d = {"a": 1, "b": 2, "c": 3, "d": 4}
 
-    result = tlz.valfilter(lambda x: x > 2, d)
+    def value_greater_than_2(x: int) -> bool:
+        return x > 2
+
+    result = tlz.valfilter(value_greater_than_2, d)
 
     _ = assert_type(result, dict[str, int])
     assert result == {"c": 3, "d": 4}


### PR DESCRIPTION
Tell me if it is easier to review the PR because I used multiple commits. I used `--fixup`, but IDK if that makes it easier or harder to read.

Refactor typing for `dicttoolz.get_in` to provide better type safety for deeply nested structures. Standardize TypeVar identifiers, limit keys to `collections.abc.Hashable`, and adjust the `factory` type to match its return type. Update tests to reflect these changes and uncomment previously disabled tests to ensure functionality.

See #14