### PR TITLE
Fix literal types for no_default and no_pad

### DIFF
--- a/src/toolz-stubs/itertoolz.pyi
+++ b/src/toolz-stubs/itertoolz.pyi
@@ -46,8 +46,8 @@ __all__ = (
 )
 
 ### Special types for toolz
-type _NoDefaultType = typing.Literal["__no_default__"]
-type _NoPadType = typing.Literal["__no_pad__"]
+type _NoDefaultType = typing.Literal["__no__default__"]
+type _NoPadType = typing.Literal["__no__pad__"]
 
 class _Randomable(typing.Protocol):
     def random(self) -> float: ...
@@ -574,7 +574,7 @@ def sliding_window[T](
     """
     ...
 
-no_pad = "__no_pad__"
+no_pad = "__no__pad__"
 
 @typing.overload
 def partition[T, P](

--- a/src/toolz-stubs/sandbox/parallel.pyi
+++ b/src/toolz-stubs/sandbox/parallel.pyi
@@ -12,7 +12,7 @@ type _MapFunction[T] = collections.abc.Callable[
 def fold[T](
     binop: collections.abc.Callable[[T, T], T],
     seq: collections.abc.Iterable[T],
-    default: typing.Literal["__no__default__"] | T = "__no_default__",
+    default: typing.Literal["__no__default__"] | T = "__no__default__",
     map: _MapFunction[T] = map,
     chunksize: int = 128,
     combine: collections.abc.Callable[[T, T], T] | None = None,


### PR DESCRIPTION
Correct the literal types for no_default and no_pad to include underscores in their names.